### PR TITLE
Configure Dependabot to check for outdated npm package dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# See: https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#about-the-dependabotyml-file
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    assignees:
+      - per1234
+    labels:
+      - "topic: infrastructure"
+    open-pull-requests-limit: 100
+    schedule:
+      interval: daily

--- a/docs/acknowledgments.md
+++ b/docs/acknowledgments.md
@@ -26,6 +26,7 @@ This project is based on many amazing open source software projects:
 ### Misc
 
 - [**arduino/tooling-project-assets**](https://github.com/arduino/tooling-project-assets) - Collection of reusable project infrastructure assets
+- [**Dependabot**](https://docs.github.com/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) - Dependency update service
 
 ## Resources
 


### PR DESCRIPTION
Dependabot will periodically check the versions of all the project's npm package dependencies. If any are found to be outdated, it will submit a pull request to update them.