### PR TITLE
Add CI workflow to check the license file

### DIFF
--- a/.github/workflows/check-license.yml
+++ b/.github/workflows/check-license.yml
@@ -1,0 +1,63 @@
+name: Check License
+
+env:
+  EXPECTED_LICENSE_FILENAME: LICENSE.txt
+  # SPDX identifier: https://spdx.org/licenses/
+  EXPECTED_LICENSE_TYPE: MIT
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/check-license.ya?ml"
+      # See: https://github.com/licensee/licensee/blob/master/docs/what-we-look-at.md#detecting-the-license-file
+      - "[cC][oO][pP][yY][iI][nN][gG]*"
+      - "[cC][oO][pP][yY][rR][iI][gG][hH][tH]*"
+      - "[lL][iI][cC][eE][nN][cCsS][eE]*"
+      - "[oO][fF][lL]*"
+      - "[pP][aA][tT][eE][nN][tT][sS]*"
+  pull_request:
+    paths:
+      - ".github/workflows/check-license.ya?ml"
+      - "[cC][oO][pP][yY][iI][nN][gG]*"
+      - "[cC][oO][pP][yY][rR][iI][gG][hH][tH]*"
+      - "[lL][iI][cC][eE][nN][cCsS][eE]*"
+      - "[oO][fF][lL]*"
+      - "[pP][aA][tT][eE][nN][tT][sS]*"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  check-license:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby # Install latest version
+
+      - name: Install licensee
+        run: gem install licensee
+
+      - name: Check license file
+        run: |
+          # See: https://github.com/licensee/licensee
+          LICENSEE_OUTPUT="$(licensee detect --json --confidence=100)"
+
+          DETECTED_LICENSE_FILE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].filename | tr --delete '\r')"
+          echo "Detected license file: $DETECTED_LICENSE_FILE"
+          if [ "$DETECTED_LICENSE_FILE" != "\"$EXPECTED_LICENSE_FILENAME\"" ]; then
+            echo "ERROR: detected license file doesn't match expected: $EXPECTED_LICENSE_FILENAME"
+            exit 1
+          fi
+
+          DETECTED_LICENSE_TYPE="$(echo "$LICENSEE_OUTPUT" | jq .matched_files[0].matched_license | tr --delete '\r')"
+          echo "Detected license type: $DETECTED_LICENSE_TYPE"
+          if [ "$DETECTED_LICENSE_TYPE" != "\"$EXPECTED_LICENSE_TYPE\"" ]; then
+            echo "ERROR: detected license type doesn't match expected $EXPECTED_LICENSE_TYPE"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # @per1234/generator-kb-document
 
+[![Check License status](https://github.com/per1234/generator-kb-document/actions/workflows/check-license.yml/badge.svg)](https://github.com/per1234/generator-kb-document/actions/workflows/check-license.yml)
 [![Check npm status](https://github.com/per1234/generator-kb-document/actions/workflows/check-npm-task.yml/badge.svg)](https://github.com/per1234/generator-kb-document/actions/workflows/check-npm-task.yml)
 
 This is a [**Yeoman**](https://yeoman.io/) generator that creates a new document in a [**Markdown**](https://daringfireball.net/projects/markdown/) file-based knowledge base.

--- a/docs/acknowledgments.md
+++ b/docs/acknowledgments.md
@@ -15,6 +15,7 @@ This project is based on many amazing open source software projects:
 - [**actions/checkout**](https://github.com/actions/checkout)
 - [**actions/setup-go**](https://github.com/actions/setup-go)
 - [**actions/setup-node**](https://github.com/actions/setup-node)
+- [**ruby/setup-ruby**](https://github.com/ruby/setup-ruby)
 
 ### Programming/Markup Languages
 
@@ -28,6 +29,7 @@ This project is based on many amazing open source software projects:
 - [**ajv-cli**](https://ajv.js.org/packages/ajv-cli.html) - JSON schema validator
 - [**Git**](https://git-scm.com/) - Version control system.
 - [**gvm**](https://github.com/moovweb/gvm) - Go version manager
+- [**Licensee**](https://github.com/licensee/licensee) - License file parser
 - [**Node.js**](https://nodejs.org/en/download/package-manager) - JavaScript runtime environment
 - [**npm**](https://docs.npmjs.com/cli/) - JavaScript package manager
 - [**nvm**](https://github.com/nvm-sh/nvm) - Node.js version manager


### PR DESCRIPTION
Whenever one of the recognized license file names are modified in the repository, the workflow runs to check whether the license can be recognized and whether it is of the expected type.

GitHub has a useful automated license detection system that determines the license type used by a repository, and surfaces that information in the repository home page, the search web interface, and the GitHub API. This license detection system requires that the license be defined by a dedicated file with one of several standardized filenames and paths.

GitHub's license detection system uses the popular licensee tool, so this file also serves to define the license type for any other usages of licensee, as well as to human readers of the file.

For this reason, and to ensure it remains a valid legal instrument, it's important that there be no non-standard modifications to the license file or collisions with other supported license files. This workflow ensures that any changes which would change the license type or which license file is used by the detection are caught automatically.