### PR TITLE
Add CI workflow to check Go dependencies manifest

### DIFF
--- a/.github/workflows/check-go-task.yml
+++ b/.github/workflows/check-go-task.yml
@@ -1,0 +1,94 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-go-task.md
+name: Check Go
+
+# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+on:
+  create:
+  push:
+    paths:
+      - ".github/workflows/check-go-task.ya?ml"
+      - "Taskfile.ya?ml"
+      - ".golangci.ya?ml"
+      - "**/go.mod"
+      - "**/go.sum"
+      - "**.go"
+  pull_request:
+    paths:
+      - ".github/workflows/check-go-task.ya?ml"
+      - "Taskfile.ya?ml"
+      - ".golangci.ya?ml"
+      - "**/go.mod"
+      - "**/go.sum"
+      - "**.go"
+  schedule:
+    # Run periodically to catch breakage caused by external changes.
+    - cron: "0 7 * * WED"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[
+            "${{ github.event_name }}" != "create" ||
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "result=$RESULT" >> $GITHUB_OUTPUT
+
+  check-config:
+    name: check-config (${{ matrix.module.path }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        module:
+          - path: .
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ${{ matrix.module.path }}/go.mod
+
+      - name: Install Task
+        run: |
+          go \
+            install \
+              github.com/go-task/task/v3/cmd/task
+
+      - name: Run go mod tidy
+        env:
+          GO_MODULE_PATH: ${{ matrix.module.path }}
+        run: task go:tidy
+
+      - name: Check whether any tidying was needed
+        run: |
+          git \
+            diff \
+            --color \
+            --exit-code

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Check Files status](https://github.com/per1234/generator-kb-document/actions/workflows/check-files-task.yml/badge.svg)](https://github.com/per1234/generator-kb-document/actions/workflows/check-files-task.yml)
 [![Check General Formatting status](https://github.com/per1234/generator-kb-document/actions/workflows/check-general-formatting-task.yml/badge.svg)](https://github.com/per1234/generator-kb-document/actions/workflows/check-general-formatting-task.yml)
+[![Check Go status](https://github.com/per1234/generator-kb-document/actions/workflows/check-go-task.yml/badge.svg)](https://github.com/per1234/generator-kb-document/actions/workflows/check-go-task.yml)
 [![Check License status](https://github.com/per1234/generator-kb-document/actions/workflows/check-license.yml/badge.svg)](https://github.com/per1234/generator-kb-document/actions/workflows/check-license.yml)
 [![Check npm status](https://github.com/per1234/generator-kb-document/actions/workflows/check-npm-task.yml/badge.svg)](https://github.com/per1234/generator-kb-document/actions/workflows/check-npm-task.yml)
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -18,6 +18,11 @@ tasks:
       - task: general:check-symlinks
       - task: npm:validate
 
+  fix:
+    desc: Make automated corrections to the project's files
+    deps:
+      - task: go:tidy
+
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-files-task/Taskfile.yml
   general:check-filenames:
     desc: Check for non-portable filenames
@@ -125,6 +130,20 @@ tasks:
           echo 'Broken or circular symlink found'
           false
         }
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-go-task/Taskfile.yml
+  go:tidy:
+    desc: |
+      Refresh dependency metadata.
+      Environment variable parameters:
+      GO_MODULE_PATH: Path of the Go module (default: {{.DEFAULT_GO_MODULE_PATH}}).
+    dir: "{{default .DEFAULT_GO_MODULE_PATH .GO_MODULE_PATH}}"
+    cmds:
+      - |
+        go \
+          mod \
+            tidy \
+              -compat={{.GO_VERSION}}
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/npm-task/Taskfile.yml
   npm:install-deps:

--- a/docs/development.md
+++ b/docs/development.md
@@ -28,6 +28,16 @@ You can run the full suite of checks by running the following command from a ter
 task check
 ```
 
+### Automatic Corrections
+
+Tools are provided to automatically bring the project into compliance with some of the required checks.
+
+You can make these automatic fixes by running the following command from a terminal in a path under the repository:
+
+```text
+task fix
+```
+
 ### Other Operations
 
 Individual tasks are provided for each specific common validation and automated correction operation. The convenience `check` and `fix` tasks run all of the relevant individual tasks, so it is not necessary for the contributor to use the individual tasks. However, in some cases it may be more efficient to run the single specific task of interest.


### PR DESCRIPTION
Add a task to tidy the project's Go module dependency manifest.

On every push and pull request that affects relevant files, the added Github Actions workflow will run the task and then check for an out of sync Go module dependencies manifest.