### PR TITLE
Configure Dependabot to check for outdated Python package dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,12 @@ updates:
     open-pull-requests-limit: 100
     schedule:
       interval: daily
+  - package-ecosystem: pip
+    directory: /
+    assignees:
+      - per1234
+    labels:
+      - "topic: infrastructure"
+    open-pull-requests-limit: 100
+    schedule:
+      interval: daily


### PR DESCRIPTION
Dependabot will periodically check the versions of all the project's Python package dependencies. If any are found to be outdated, it will submit a pull request to update them.