### PR TITLE
Add npm package release infrastructure

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,80 @@
+name: Release npm Package
+
+on:
+  push:
+    tags:
+      - "v?[0-9]+.[0-9]+.[0-9]+*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      # See: https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
+      id-token: write
+
+    env:
+      # See: https://github.com/fsaintjacques/semver-tool/releases
+      SEMVER_TOOL_VERSION: 3.4.0
+
+    steps:
+      - name: Set environment variables
+        run: |
+          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "SEMVER_TOOL_PATH=${{ runner.temp }}/semver" >> "$GITHUB_ENV"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+          registry-url: https://registry.npmjs.org
+
+      - name: Download semver tool
+        id: download-semver-tool
+        uses: carlosperate/download-file-action@v2
+        with:
+          file-url: https://github.com/fsaintjacques/semver-tool/archive/${{ env.SEMVER_TOOL_VERSION }}.zip
+          location: ${{ runner.temp }}/semver-tool
+
+      - name: Install semver tool
+        run: |
+          unzip \
+            -p \
+            "${{ steps.download-semver-tool.outputs.file-path }}" \
+            semver-tool-${{ env.SEMVER_TOOL_VERSION }}/src/semver > \
+              "${{ env.SEMVER_TOOL_PATH }}"
+          chmod +x "${{ env.SEMVER_TOOL_PATH }}"
+
+      - name: Detect release type
+        id: release-type
+        run: |
+          if [[ \
+            "$(
+              "${{ env.SEMVER_TOOL_PATH }}" get prerel \
+                "${GITHUB_REF/refs\/tags\//}"
+            )" != \
+            "" \
+          ]]; then
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Github release
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: false
+          prerelease: ${{ steps.release-type.outputs.prerelease }}
+
+      # See: https://docs.github.com/actions/use-cases-and-examples/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
+      - name: Publish to npm registry
+        if: steps.release-type.outputs.prerelease != 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm \
+            publish \
+              --access public \
+              --provenance

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 [![Check Taskfiles status](https://github.com/per1234/generator-kb-document/actions/workflows/check-taskfiles.yml/badge.svg)](https://github.com/per1234/generator-kb-document/actions/workflows/check-taskfiles.yml)
 [![Check Workflows status](https://github.com/per1234/generator-kb-document/actions/workflows/check-workflows-task.yml/badge.svg)](https://github.com/per1234/generator-kb-document/actions/workflows/check-workflows-task.yml)
 [![Check YAML status](https://github.com/per1234/generator-kb-document/actions/workflows/check-yaml-task.yml/badge.svg)](https://github.com/per1234/generator-kb-document/actions/workflows/check-yaml-task.yml)
+[![Release npm Package status](https://github.com/per1234/generator-kb-document/actions/workflows/release-npm.yml/badge.svg)](https://github.com/per1234/generator-kb-document/actions/workflows/release-npm.yml)
 [![Spell Check status](https://github.com/per1234/generator-kb-document/actions/workflows/spell-check-task.yml/badge.svg)](https://github.com/per1234/generator-kb-document/actions/workflows/spell-check-task.yml)
 [![Sync Labels status](https://github.com/per1234/generator-kb-document/actions/workflows/sync-labels-npm.yml/badge.svg)](https://github.com/per1234/generator-kb-document/actions/workflows/sync-labels-npm.yml)
 [![Test JavaScript status](https://github.com/per1234/generator-kb-document/actions/workflows/test-javascript-jest-task.yml/badge.svg)](https://github.com/per1234/generator-kb-document/actions/workflows/test-javascript-jest-task.yml)

--- a/assets/bump-package.sh
+++ b/assets/bump-package.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Bump the npm package version metadata.
+
+set \
+  -o \
+  errexit
+
+if [ "$1" = "" ]; then
+  echo "error: Version argument was not passed to script."
+  exit 1
+fi
+
+git \
+  checkout \
+  main
+
+git \
+  pull
+
+git \
+  checkout \
+  -b "bump-package"
+
+npm \
+  version \
+  --no-git-tag-version \
+  "$1"
+
+git \
+  add \
+  package.json \
+  package-lock.json
+
+git \
+  commit \
+  -m "Update package version to $1"
+
+git \
+  push

--- a/docs/acknowledgments.md
+++ b/docs/acknowledgments.md
@@ -27,6 +27,8 @@ This project is based on many amazing open source software projects:
 - [**actions/upload-artifact**](https://github.com/actions/upload-artifact)
 - [**carlosperate/download-file-action**](https://github.com/carlosperate/download-file-action)
 - [**geekyeggo/delete-artifact**](https://github.com/geekyeggo/delete-artifact)
+- [**liskin/gh-problem-matcher-wrap**](https://github.com/liskin/gh-problem-matcher-wrap)
+- [**ncipollo/release-action**](https://github.com/ncipollo/release-action)
 - [**ruby/setup-ruby**](https://github.com/ruby/setup-ruby)
 - [**xt0rted/markdownlint-problem-matcher**](https://github.com/xt0rted/markdownlint-problem-matcher)
 
@@ -63,6 +65,7 @@ This project is based on many amazing open source software projects:
 - [**Poetry**](https://python-poetry.org/) - Python package manager
 - [**Prettier**](https://prettier.io/) - Code formatter
 - [**Prettier Toml Plugin**](https://www.npmjs.com/package/prettier-plugin-toml) - Prettier plugin for TOML files
+- [**semver**](https://github.com/fsaintjacques/semver-tool) - Version number parsing
 - [**Task**](https://taskfile.dev/) - Task runner
 - [**Wget**](https://www.gnu.org/software/wget/) - File downloader
 - [**yamllint**](https://yamllint.readthedocs.io/) - YAML linter

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,5 +1,15 @@
 # Development Guide
 
+This is the documentation for subjects related to project development.
+
+---
+
+For information about contributing to the project, see the [**Contributor Guide**](CONTRIBUTING.md).
+
+For information about project maintenance, see the [**Maintainer Guide**](maintainer-guide/maintainer-guide.md).
+
+---
+
 ## Prerequisites
 
 The following development tools must be available in your local environment:

--- a/docs/maintainer-guide/maintainer-guide.md
+++ b/docs/maintainer-guide/maintainer-guide.md
@@ -1,0 +1,125 @@
+# Maintainer Guide
+
+This is the documentation for subjects related to maintenance of the project.
+
+---
+
+For information about project development, see the [**Development Guide**](../development.md).
+
+For information about contributing to the project, see the [**Contributor Guide**](../CONTRIBUTING.md).
+
+---
+
+## Release Procedure
+
+### A. Prepare for Release
+
+#### Validation
+
+##### Evaluate CI Status
+
+1. Open https://github.com/per1234/generator-kb-document/actions?query=branch%3Amain
+1. For each of the workflows listed at the left side of the page, do the following:
+   1. Click on the workflow name.
+   1. Check the status of the latest run.
+   1. If the run was not successful, investigate the cause and determine if it is of significance to the release.
+
+#### Versioning
+
+Determine the version number for the release.
+
+Versioning must follow [the semver specification](https://semver.org/).
+
+##### Prereleases
+
+In some cases it might be desirable to have control over the package versions used by beta testers. This is done by creating "release candidate" prereleases.
+
+These are created via the same release process described below, except that the version number has an `-rc.N` suffix (where `N` is an integer indicating the sequence of prereleases) on the tag name. This suffix indicates it is a prerelease release candidate of that version. For example, `1.2.3-rc.2` is the second release candidate for the `1.2.3` release.
+
+---
+
+**ⓘ** The prerelease versions of the package will not be published to the **npm** registry. Beta testers can install it using the [`npm install <git remote url>`](https://docs.npmjs.com/cli/commands/npm-install#:~:text=npm%20install%20%3Cgit%20remote%20url%3E) syntax. For example:
+
+```text
+npm install git://github.com/per1234/generator-kb-document.git#1.2.3-rc.2
+```
+
+### B. Compose Release Notes
+
+Compose the release notes, following the [**Release Notes Guidelines**](release-notes-guidelines.md).
+
+### C. Update Version Metadata
+
+The value of the `version` field of the package's [`package.json`](https://docs.npmjs.com/cli/configuring-npm/package-json) metadata file must be updated before making the release.
+
+1. Run the following command from the terminal:
+   ```text
+   assets/bump-package.sh "<version number>"
+   ```
+   (where `<version number>` is the version of the release.
+   - ❗ `<version number>` must use the `X.Y.Z` format (e.g., `1.2.3`).
+   - ❗ Versioning must follow [the **SemVer** specification](https://semver.org/).
+1. Open the GitHub repository:<br />
+   https://github.com/per1234/generator-kb-document
+1. Submit the pull request from the `bump-package` branch that was pushed in by the command in step (1) of this procedure.
+1. Merge the pull request.
+
+### D. Tag
+
+1. Open a Bash terminal in your local clone of the `per1234/generator-kb-document` repository.
+1. [Checkout](https://git-scm.com/docs/git-checkout) the ref for the release.
+   This will usually be the tip of the `main` branch, but it can be an earlier commit from the branch if there is development work not yet ready for release.
+   - ❗ The ref must contain the version bump from [**step (C)**](#c-update-version-metadata) of this procedure.
+1. Run the following command from the terminal:
+   ```text
+   VERSION="<version number>"
+   ```
+   (where `<version number>` is the version of the release.
+   - ❗ `<version number>` must use the `X.Y.Z` format (e.g., `1.2.3`).
+   - ❗ Versioning must follow [the **SemVer** specification](https://semver.org/).
+1. Run the following command from the terminal:
+   ```text
+   REPO_URL="https://github.com/per1234/generator-kb-document"
+   ```
+1. Run the following command from the terminal:
+   ```text
+   METADATA_VERSION="$(npm pkg get version)" && \
+   if [ "$METADATA_VERSION" != "\"$VERSION\"" ]; then \
+     echo "error: version metadata ($METADATA_VERSION) does not match tag ($VERSION)"; \
+     false; \
+   fi && \
+   git tag "$VERSION" -m "$VERSION" && \
+     read -rsp $'\n'"Tag $VERSION at $(git rev-list --max-count=1 --abbrev-commit $VERSION) will be pushed to $REPO_URL."$'\n'"Press any key to proceed, or ^C to cancel..."$'\n' -n 1 && \
+     git push $REPO_URL "$VERSION"
+   ```
+1. A prompt will be shown that describes the action that will be performed if confirmed. Check all is as expected.
+1. Press the <kbd>**Enter**</kbd> key.<br />
+   The tag will be pushed to GitHub.
+1. Open the following URL in your web browser:<br />
+   https://github.com/per1234/generator-kb-document/actions/workflows/release-npm.yml<br />
+   You will see a list of the runs of the "**Release npm package**" workflow. This workflow is triggered by the tag push and automatically handles the creation of the [GitHub release](https://docs.github.com/repositories/releasing-projects-on-github/about-releases) and publishing the release to the **npm** package registry.
+1. Click on the first item in the list of workflow runs.<br />
+   The summary page for the workflow run will open.
+1. Monitor the progress of the workflow run until you see it has completed successfully.
+
+### E. Publish Release Notes
+
+1. Open the release page:<br />
+   https://github.com/per1234/generator-kb-document/releases/latest
+1. Click the **🖉** icon near the top right corner of the page.<br />
+   The edit page for the release will open.
+1. Paste the release notes composed during [**step (B)**](#b-compose-release-notes) of this procedure into the "**Describe this release**" field.
+1. Click the "**Update release**" button at the bottom of the page.
+
+### F. Update Version Metadata Post-release
+
+In order to facilitate the identification of development versions of the package that might be used by beta testers and other users, the value of the `version` field of the package's [`package.json`](https://docs.npmjs.com/cli/configuring-npm/package-json) metadata file is set to a prerelease version between releases.
+
+1. Run the following command from the terminal:
+   ```text
+   assets/bump-package.sh "prerelease"
+   ```
+1. Open the GitHub repository:<br />
+   https://github.com/per1234/generator-kb-document
+1. Submit the pull request from the `bump-package` branch that was pushed in by the command in step (1) of this procedure.
+1. Merge the pull request.

--- a/docs/maintainer-guide/release-notes-guidelines.md
+++ b/docs/maintainer-guide/release-notes-guidelines.md
@@ -1,0 +1,159 @@
+# Release Notes Guidelines
+
+## Components
+
+### Changelog
+
+The changelog summarizes the changes of significance to the users contained in the release.
+
+---
+
+❗ Only changes relative to the previous release should be mentioned in the changelog. Changes within the release (e.g., fixing a regression introduced by a change made earlier in the release) are not of interest to the target reader.
+
+---
+
+The changes are sorted in descending chronological order within each section.
+
+#### Format
+
+The changelog title has the following format:
+
+```markdown
+## Changelog
+```
+
+Change list items have the following format:
+
+```markdown
+- <!-- TODO: description of change --> (<!-- TODO: #PR number or commit ref -->)
+```
+
+---
+
+Insignificant dependency bumps can be aggregated into a single changelog item:
+
+```markdown
+- [Various dependency updates](https://github.com/per1234/generator-kb-document/pulls?q=merged%3A<!-- TODO: date after previous release -->..<!-- TODO: date of release -->+author%3Aapp%2Fdependabot)
+```
+
+(where `<!-- TODO: date after previous release>` is the YYYY-MM-DD format date of the day after the previous release date and `<!-- TODO: date of release -->` is the date of the current release)
+
+#### Categories
+
+The change lists are separated into the following categories:
+
+---
+
+❗ If there are no changes for a given category, omit the category from the release notes.
+
+---
+
+##### Breaking
+
+A list of changes which will require adjustments to the workflow of dependent projects or users.
+
+Some projects do not have a formal API. In this case, the distinction of what is "breaking" is not so straightforward. However, it is still important to clearly communicate about changes which will require adjustments to the way the project is used.
+
+###### Format
+
+```markdown
+### Breaking
+```
+
+##### Bug Fix
+
+A list of fixes for defects in any component of the project.
+
+###### Format
+
+```markdown
+### Bug Fix
+```
+
+##### Enhancement
+
+A list of enhancements to any component of the project.
+
+###### Format
+
+```markdown
+### Enhancement
+```
+
+### "Full Changeset" Link
+
+Link to a GitHub "three dot diff" between this tag and the previous tag.
+
+#### Format
+
+```markdown
+## Full Changeset
+
+https://github.com/per1234/generator-kb-document/compare/<!-- TODO: previous tag -->...<!-- TODO: release tag -->
+```
+
+❗ Replace the "`<!-- TODO: ... -->`" placeholders with the correct information for the project and release.
+
+### Contributors
+
+A list of mentions of GitHub users from the community who contributed to the release in any of the following ways:
+
+- Submitted a PR that was merged
+- Made a significant review of a PR
+- Submitted an issue that was resolved
+- Provided significant assistance with the investigation of an issue that was resolved
+
+Sort the list in alphabetical order.
+
+###### Format
+
+```markdown
+## Contributors
+
+- @<!-- TODO: username -->
+```
+
+## Procedure
+
+1. Open a comparison of the ref to be released against the previous release's tag:
+   ```text
+   https://github.com/per1234/generator-kb-document/compare/<!-- TODO: previous release ref -->...<!-- TODO: release ref -->
+   ```
+1. Evaluate each of the listed commits, selecting those of significance to users.
+1. Open the page of the significant commit.
+1. Open the page of the pull request that introduced the commit.
+1. If the pull request introduced multiple commits, determine whether the PR is "atomic" from a changelog perspective.<br />
+   If so, use the PR number in the change list item.
+   If not, use the ref of the significant commit(s) in the change list item(s).
+1. If the pull request was submitted by a community member, add their username to the contributors list.
+1. If a community member made a significant review of the PR, add their username to the contributors list.
+1. If the pull request resolved issues, open each of their pages.
+1. If the issue resolved by the pull request was submitted by a community member, add them to the contributors list.
+   If a community member provided significant assistance in the investigation of the issue, add them to the contributors list.
+
+## Example
+
+```markdown
+## Changelog
+
+#### Breaking
+
+- Rename the `Foo` function to `Bar` (#42)
+
+#### Bug Fix
+
+- Fix hang on Windows when `baz` is set to false (3b2e6dd)
+
+#### Enhancement
+
+- Specify path to file in output from `qux` command (#123)
+
+## Full Changeset
+
+https://github.com/per1234/generator-kb-document/compare/1.0.0...2.0.0
+
+## Contributors
+
+- @ArduinoBot
+- @octocat
+```

--- a/package.json
+++ b/package.json
@@ -34,5 +34,6 @@
     "yeoman-generator"
   ],
   "main": "index.js",
+  "repository": "github:per1234/generator-kb-document",
   "type": "module"
 }


### PR DESCRIPTION
In order to facilitate the use of the generator, the package is published to the npm registry.

A formal release procedure is defined in the project's Maintainer Guide.

A GiHub Actions workflow is added to automatically generate a GitHub release for every release tag, and publish the package to the npm registry on every production release.