### PR TITLE
Use JSON schema to validate prompt data

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ https://github.com/SBoudrias/Inquirer.js/tree/main/packages/prompts#prompts
 
 For a better understanding of the prompts data file format and functionality, see the [**Example** section](#example).
 
+---
+
+**ⓘ** A [JSON schema](https://json-schema.org/) for validation of the prompts data is provided [**here**](etc/generator-kb-document-prompts-data-schema.json).
+
+---
+
 ### Document File Template
 
 This file is the template for the knowledge base document files that will be created by the generator.

--- a/docs/acknowledgments.md
+++ b/docs/acknowledgments.md
@@ -12,6 +12,7 @@ This project is based on many amazing open source software projects:
 
 ### Code Dependencies
 
+- [**Ajv**](https://ajv.js.org/packages/ajv-cli.html) - JSON schema validator
 - [**Inquirer**](https://github.com/SBoudrias/Inquirer.js) - Interactive command line user interface
 - [**slug**](https://github.com/Trott/slug) - String slugifier
 - [**yeoman-generator**](https://github.com/yeoman/generator) - Yeoman generator framework

--- a/etc/generator-kb-document-prompts-data-schema.json
+++ b/etc/generator-kb-document-prompts-data-schema.json
@@ -1,0 +1,11 @@
+{
+  "title": "JSON schema for the @per1234/generator-kb-document prompts data file",
+  "description": "See: https://github.com/per1234/generator-kb-document#prompts-data-file",
+  "$id": "https://raw.githubusercontent.com/per1234/generator-kb-document/main/etc/generator-kb-document-prompts-data-schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object"
+  },
+  "uniqueItems": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@per1234/generator-kb-document",
       "version": "0.1.0-beta",
       "dependencies": {
+        "ajv": "8.17.1",
         "slug": "9.1.0",
         "yeoman-generator": "7.3.2"
       },
@@ -2787,7 +2788,6 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5402,8 +5402,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
@@ -5469,8 +5468,7 @@
     "node_modules/fast-uri": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
-      "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
-      "dev": true
+      "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw=="
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -8413,8 +8411,7 @@
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -11009,7 +11006,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15771,7 +15767,6 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -17672,8 +17667,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-fifo": {
       "version": "1.3.2",
@@ -17734,8 +17728,7 @@
     "fast-uri": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
-      "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
-      "dev": true
+      "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw=="
     },
     "fastq": {
       "version": "1.17.1",
@@ -19826,8 +19819,7 @@
     "json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -21740,8 +21732,7 @@
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "resolve": {
       "version": "1.22.8",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@per1234/generator-kb-document",
   "version": "0.1.0-beta",
   "dependencies": {
+    "ajv": "8.17.1",
     "slug": "9.1.0",
     "yeoman-generator": "7.3.2"
   },
@@ -28,7 +29,8 @@
     "node": "20.x"
   },
   "files": [
-    "app"
+    "app/",
+    "etc/"
   ],
   "keywords": [
     "yeoman-generator"

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -103,7 +103,7 @@ describe("running the generator", () => {
           .run(Generator, generatorOptions)
           .withAnswers(answers)
           .withLocalConfig(localConfig),
-      ).rejects.toThrow("not an array"));
+      ).rejects.toThrow("must be array"));
   });
 
   describe.each([


### PR DESCRIPTION
The object exported by the prompt data file must have a specific data format. This data is provided by the user, so the validity can not be assumed. It will be useful for the generator to do thorough validation of the data and provide detailed communication to the user of any problems that are found.

Previously, some validation was done, but it was incomplete even with the current simple data format. That approach will not scale as the expansion of the generator capabilities results in increased complexity of the prompt data format. The standard way to accomplish this is by validating the data against a schema.

The schema is stored in a dedicated standard JSON schema file. In addition to the schema's use by the generator itself, this also offers users the option to directly validate their prompt data files against the JSON schema, which might be useful for their development and continuous integration systems.