### PR TITLE
Support generation of complete front matter document from prompts

### DIFF
--- a/docs/acknowledgments.md
+++ b/docs/acknowledgments.md
@@ -13,8 +13,10 @@ This project is based on many amazing open source software projects:
 ### Code Dependencies
 
 - [**Ajv**](https://ajv.js.org/packages/ajv-cli.html) - JSON schema validator
+- [**JSON Pointer for Node.js**](https://github.com/janl/node-jsonpointer) - JSON pointer implementation
 - [**Inquirer**](https://github.com/SBoudrias/Inquirer.js) - Interactive command line user interface
 - [**slug**](https://github.com/Trott/slug) - String slugifier
+- [**yaml**](https://github.com/eemeli/yaml) - YAML parser and stringifier for JavaScript
 - [**yeoman-generator**](https://github.com/yeoman/generator) - Yeoman generator framework
 - [**yeoman-test**](https://github.com/yeoman/yeoman-test) - Utilities for testing Yeoman generators
 

--- a/etc/generator-kb-document-prompts-data-schema.json
+++ b/etc/generator-kb-document-prompts-data-schema.json
@@ -5,7 +5,26 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "array",
   "items": {
-    "type": "object"
+    "type": "object",
+    "properties": {
+      "inquirer": {
+        "type": "object"
+      },
+      "usage": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": ["content", "front matter"]
+        },
+        "minItems": 1,
+        "uniqueItems": true
+      },
+      "frontMatterPath": {
+        "type": "string",
+        "minLength": 2
+      }
+    },
+    "required": ["inquirer", "usage"]
   },
   "uniqueItems": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.1.0-beta",
       "dependencies": {
         "ajv": "8.17.1",
+        "jsonpointer": "5.0.1",
         "slug": "9.1.0",
+        "yaml": "2.5.0",
         "yeoman-generator": "7.3.2"
       },
       "devDependencies": {
@@ -8507,7 +8509,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
       "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12956,6 +12957,17 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.0.tgz",
+      "integrity": "sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",
@@ -19890,8 +19902,7 @@
     "jsonpointer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
-      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
-      "dev": true
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="
     },
     "jsprim": {
       "version": "1.4.2",
@@ -23146,6 +23157,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
+    },
+    "yaml": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.0.tgz",
+      "integrity": "sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw=="
     },
     "yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0-beta",
   "dependencies": {
     "ajv": "8.17.1",
+    "jsonpointer": "5.0.1",
     "slug": "9.1.0",
+    "yaml": "2.5.0",
     "yeoman-generator": "7.3.2"
   },
   "devDependencies": {

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -26,7 +26,7 @@ describe("running the generator", () => {
       "nonexistent-prompts-data",
     );
     const answers = {
-      title: documentTitle,
+      kbDocumentTitle: documentTitle,
     };
     const localConfig = {
       kbPath: "kb",
@@ -46,7 +46,7 @@ describe("running the generator", () => {
   describe("with nonexistent template path", () => {
     const thisTestDataPath = path.join(testDataPath, "nonexistent-template");
     const answers = {
-      title: documentTitle,
+      kbDocumentTitle: documentTitle,
     };
     const localConfig = {
       kbPath: "kb",
@@ -69,7 +69,7 @@ describe("running the generator", () => {
       "no-prompts-data-default-export",
     );
     const answers = {
-      title: documentTitle,
+      kbDocumentTitle: documentTitle,
     };
     const localConfig = {
       kbPath: "kb",
@@ -89,7 +89,7 @@ describe("running the generator", () => {
   describe("with prompts data that is not an array", () => {
     const thisTestDataPath = path.join(testDataPath, "prompts-data-not-array");
     const answers = {
-      title: documentTitle,
+      kbDocumentTitle: documentTitle,
     };
     const localConfig = {
       kbPath: "kb",

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -106,6 +106,30 @@ describe("running the generator", () => {
       ).rejects.toThrow("must be array"));
   });
 
+  describe("with prompt data missing required frontMatterPath property", () => {
+    const thisTestDataPath = path.join(
+      testDataPath,
+      "prompt-data-missing-frontMatterPath",
+    );
+    const answers = {
+      kbDocumentTitle: documentTitle,
+      fooPrompt: "plutoChoice",
+    };
+    const localConfig = {
+      kbPath: "kb",
+      promptsDataPath: path.join(thisTestDataPath, "prompts.js"),
+      templatePath: path.join(thisTestDataPath, "primary-document.ejs"),
+    };
+
+    test("rejects", () =>
+      expect(
+        helpers
+          .run(Generator, generatorOptions)
+          .withAnswers(answers)
+          .withLocalConfig(localConfig),
+      ).rejects.toThrow("missing frontMatterPath"));
+  });
+
   describe.each([
     {
       description: "no user prompts",
@@ -115,11 +139,37 @@ describe("running the generator", () => {
       },
     },
     {
-      description: "has user prompts",
-      testdataFolderName: "with-prompts-data",
+      description: "user prompt with content usage",
+      testdataFolderName: "content-usage-prompt-data",
       answers: {
         kbDocumentTitle: documentTitle,
-        fooPromptName: "foo prompt answer",
+        fooPrompt: "foo prompt answer",
+      },
+    },
+    {
+      description: "user prompt with front matter usage, array path",
+      testdataFolderName: "array-path-front-matter-usage-prompt-data",
+      answers: {
+        kbDocumentTitle: documentTitle,
+        fooPrompt: "plutoChoice",
+        barPrompt: "asdfChoice",
+      },
+    },
+    {
+      description: "object prompt with front matter usage, object path",
+      testdataFolderName: "object-path-front-matter-usage-prompt-data",
+      answers: {
+        kbDocumentTitle: documentTitle,
+        fooPrompt: "plutoChoice",
+        barPrompt: "asdfChoice",
+      },
+    },
+    {
+      description: "user prompt with content+front matter usage",
+      testdataFolderName: "content-front-matter-usage-prompt-data",
+      answers: {
+        kbDocumentTitle: documentTitle,
+        fooPrompt: "plutoChoice",
       },
     },
   ])(

--- a/tests/testdata/array-path-front-matter-usage-prompt-data/golden/foo-title/doc.md
+++ b/tests/testdata/array-path-front-matter-usage-prompt-data/golden/foo-title/doc.md
@@ -1,0 +1,7 @@
+---
+tags:
+  - plutoChoice
+  - asdfChoice
+---
+
+# Foo Title

--- a/tests/testdata/array-path-front-matter-usage-prompt-data/primary-document.ejs
+++ b/tests/testdata/array-path-front-matter-usage-prompt-data/primary-document.ejs
@@ -1,0 +1,3 @@
+<%- kbDocumentFrontMatter %>
+
+# <%- kbDocumentTitle %>

--- a/tests/testdata/array-path-front-matter-usage-prompt-data/prompts.js
+++ b/tests/testdata/array-path-front-matter-usage-prompt-data/prompts.js
@@ -1,0 +1,42 @@
+const prompts = [
+  {
+    frontMatterPath: "/tags/-",
+    inquirer: {
+      type: "rawlist",
+      name: "fooPrompt",
+      message: "Foo message:",
+      choices: [
+        {
+          name: "Pippo choice",
+          value: "pippoChoice",
+        },
+        {
+          name: "Pluto choice",
+          value: "plutoChoice",
+        },
+      ],
+    },
+    usage: ["front matter"],
+  },
+  {
+    frontMatterPath: "/tags/-",
+    inquirer: {
+      type: "rawlist",
+      name: "barPrompt",
+      message: "Bar message:",
+      choices: [
+        {
+          name: "Asdf choice",
+          value: "asdfChoice",
+        },
+        {
+          name: "Qwer choice",
+          value: "qwerChoice",
+        },
+      ],
+    },
+    usage: ["front matter"],
+  },
+];
+
+export default prompts;

--- a/tests/testdata/content-front-matter-usage-prompt-data/golden/foo-title/doc.md
+++ b/tests/testdata/content-front-matter-usage-prompt-data/golden/foo-title/doc.md
@@ -1,0 +1,8 @@
+---
+tags:
+  - plutoChoice
+---
+
+# Foo Title
+
+Foo prompt: plutoChoice

--- a/tests/testdata/content-front-matter-usage-prompt-data/primary-document.ejs
+++ b/tests/testdata/content-front-matter-usage-prompt-data/primary-document.ejs
@@ -1,0 +1,5 @@
+<%- kbDocumentFrontMatter %>
+
+# <%- kbDocumentTitle %>
+
+Foo prompt: <%- fooPrompt %>

--- a/tests/testdata/content-front-matter-usage-prompt-data/prompts.js
+++ b/tests/testdata/content-front-matter-usage-prompt-data/prompts.js
@@ -1,0 +1,23 @@
+const prompts = [
+  {
+    frontMatterPath: "/tags/-",
+    inquirer: {
+      type: "rawlist",
+      name: "fooPrompt",
+      message: "Foo message:",
+      choices: [
+        {
+          name: "Pippo choice",
+          value: "pippoChoice",
+        },
+        {
+          name: "Pluto choice",
+          value: "plutoChoice",
+        },
+      ],
+    },
+    usage: ["content", "front matter"],
+  },
+];
+
+export default prompts;

--- a/tests/testdata/content-usage-prompt-data/golden/foo-title/doc.md
+++ b/tests/testdata/content-usage-prompt-data/golden/foo-title/doc.md
@@ -1,0 +1,3 @@
+# Foo Title
+
+Foo prompt: foo prompt answer

--- a/tests/testdata/content-usage-prompt-data/primary-document.ejs
+++ b/tests/testdata/content-usage-prompt-data/primary-document.ejs
@@ -1,0 +1,3 @@
+# <%- kbDocumentTitle %>
+
+Foo prompt: <%- fooPrompt %>

--- a/tests/testdata/content-usage-prompt-data/prompts.js
+++ b/tests/testdata/content-usage-prompt-data/prompts.js
@@ -1,0 +1,12 @@
+const prompts = [
+  {
+    inquirer: {
+      type: "input",
+      name: "fooPrompt",
+      message: "Foo message:",
+    },
+    usage: ["content"],
+  },
+];
+
+export default prompts;

--- a/tests/testdata/object-path-front-matter-usage-prompt-data/golden/foo-title/doc.md
+++ b/tests/testdata/object-path-front-matter-usage-prompt-data/golden/foo-title/doc.md
@@ -1,0 +1,7 @@
+---
+foo:
+  bar: plutoChoice
+  baz: asdfChoice
+---
+
+# Foo Title

--- a/tests/testdata/object-path-front-matter-usage-prompt-data/primary-document.ejs
+++ b/tests/testdata/object-path-front-matter-usage-prompt-data/primary-document.ejs
@@ -1,0 +1,3 @@
+<%- kbDocumentFrontMatter %>
+
+# <%- kbDocumentTitle %>

--- a/tests/testdata/object-path-front-matter-usage-prompt-data/prompts.js
+++ b/tests/testdata/object-path-front-matter-usage-prompt-data/prompts.js
@@ -1,0 +1,42 @@
+const prompts = [
+  {
+    frontMatterPath: "/foo/bar",
+    inquirer: {
+      type: "rawlist",
+      name: "fooPrompt",
+      message: "Foo message:",
+      choices: [
+        {
+          name: "Pippo choice",
+          value: "pippoChoice",
+        },
+        {
+          name: "Pluto choice",
+          value: "plutoChoice",
+        },
+      ],
+    },
+    usage: ["front matter"],
+  },
+  {
+    frontMatterPath: "/foo/baz",
+    inquirer: {
+      type: "rawlist",
+      name: "barPrompt",
+      message: "Bar message:",
+      choices: [
+        {
+          name: "Asdf choice",
+          value: "asdfChoice",
+        },
+        {
+          name: "Qwer choice",
+          value: "qwerChoice",
+        },
+      ],
+    },
+    usage: ["front matter"],
+  },
+];
+
+export default prompts;

--- a/tests/testdata/prompt-data-missing-frontMatterPath/prompts.js
+++ b/tests/testdata/prompt-data-missing-frontMatterPath/prompts.js
@@ -1,0 +1,22 @@
+const prompts = [
+  {
+    inquirer: {
+      type: "rawlist",
+      name: "fooPrompt",
+      message: "Foo message:",
+      choices: [
+        {
+          name: "Pippo choice",
+          value: "pippoChoice",
+        },
+        {
+          name: "Pluto choice",
+          value: "plutoChoice",
+        },
+      ],
+    },
+    usage: ["front matter"],
+  },
+];
+
+export default prompts;

--- a/tests/testdata/with-prompts-data/golden/foo-title/doc.md
+++ b/tests/testdata/with-prompts-data/golden/foo-title/doc.md
@@ -1,3 +1,0 @@
-# Foo Title
-
-Foo: foo prompt answer

--- a/tests/testdata/with-prompts-data/primary-document.ejs
+++ b/tests/testdata/with-prompts-data/primary-document.ejs
@@ -1,3 +1,0 @@
-# <%- kbDocumentTitle %>
-
-Foo: <%- fooPromptName %>

--- a/tests/testdata/with-prompts-data/prompts.js
+++ b/tests/testdata/with-prompts-data/prompts.js
@@ -1,9 +1,0 @@
-const prompts = [
-  {
-    type: "input",
-    name: "fooPromptName",
-    message: "Foo Message",
-  },
-];
-
-export default prompts;


### PR DESCRIPTION
The generator is intended to be used with knowledge bases that are organized by tags. The tags are associated with a document via the standard `tags` key of the Markdown front matter. Since the tags should be standardized for the KB, and will often form related sets or alternatives, it will be convenient for the user to select the tags for a new document via prompts.

Although it is possible to then reference the answers to these prompts directly in the document template to form the front matter, this is prone to human error and also can require a significant amount of template content (especially with the more advanced tagging use cases that will be supported by the generator in the future). In order to relieve the user from the burden of developing and maintaining this template content in each dependent project, it will be helpful for the generator to generate the full front matter content, making it available for insertion into the document by a single simple variable reference in the template.