### PR TITLE
Disable internal anchor checks by link checker tool

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -7,6 +7,11 @@
       }
     }
   ],
+  "ignorePatterns": [
+    {
+      "pattern": "^#"
+    }
+  ],
   "retryOn429": true,
   "retryCount": 3,
   "aliveStatusCodes": [200, 206]


### PR DESCRIPTION
[The "**markdown-link-check**" tool] is used to check for broken links in this project's Markdown files.

Validation of links to internal anchors was recently added to the tool (https://github.com/tcort/markdown-link-check/commit/65221868bb1101bf211f9791037f304eacf908a2).

Although a much needed feature, unfortunately it does not currently support anchors created by HTML anchor tags (https://github.com/tcort/markdown-link-check/issues/195).

For example, this is valid and common Markdown:

```markdown
[click here](#some-anchor)
<a name="some-anchor"></a>
```

but will fail the check:

```text
ERROR: 1 dead links found!
[x] #some-anchor -> Status: 404
```

This type of link markup is used in cases where the anchors automatically generated for the headings might be ambiguous.

The solution is to configure markdown-link-check to skip these links.

This change should be be reverted whenever the tool is able to correctly validate all internal anchor links.