### PR TITLE
Don't export NODE_OPTIONS variable in js:test task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -292,8 +292,7 @@ tasks:
     cmds:
       # See: https://jestjs.io/docs/ecmascript-modules#:~:text=Execute%20node%20with%20%2D%2Dexperimental%2Dvm%2Dmodules
       - |
-        export NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules" \
-        && \
+        NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules" \
         npx \
           jest \
             --coverage


### PR DESCRIPTION
The project is an ECMAScript module. In order to be able to test this type of module using the Jest test framework, it is necessary to use a feature of Node.js that is currently in experimental status.

This feature is enabled by passing the `--experimental-vm-modules` flag to `node`. Since we are invoking `jest` rather than `node`, this is done by putting the flag to the `NODE_OPTIONS` environment variable. Since the feature is not normally needed, this is done only when invoking `jest` via the `js:test` task. Since `NODE_OPTIONS` might already contain content that was set previously, this is done by appending the flag to the existing content of the variable.

Previously, the task used `export` when adding the flag to the variable. This is unnecessary and is not best practices for this application where the intent is to only set the value of the variable for the invocation of the command, rather than setting it for the duration of the shell session. There isn't actually any functional difference in this case since this is the task's `cmd` element uses a dedicated shell and only invokes this single command, but additional invocations might later be added to the task, and be impacted by the unexpected presence of this flag in `NODE_OPTIONS`. So it is still best to remove the unnecessary `export`. This also avoids uncertainty regarding whether the export will propagate to subsequent `cmd` elements in the task, or to the calling shell (it does not, but the nature of how Task handles shell sessions is not obvious to the casual task user.