### PR TITLE
Document the usage of the array element append JSON pointer syntax in `frontMatterPath`

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,13 +157,13 @@ https://datatracker.ietf.org/doc/html/rfc6901
 
 ---
 
-##### Example
+##### Object as Path
 
 With the following prompt configuration object:
 
 ```javascript
 {
-  frontMatterPath: "/tags/-",
+  frontMatterPath: "/tags",
   inquirer: {
     type: "rawlist",
     name: "someTag",
@@ -189,7 +189,25 @@ And the following [document file template](#document-file-template):
 <%- kbDocumentFrontMatter %>
 ```
 
-If the user answers "**Foo**" to the "**Some tag:**" prompt, the generated document will contain:
+If the user answers "**Foo**" to the "**Some tag:**" prompt, the value of the `tags` key in the root object (AKA "[mapping](https://www.yaml.info/learn/index.html#:~:text=items%20and%20more.-,Mapping,-The%20most%20common) in YAML language terminology) will be set to the answer value `foo`. The front matter in the generated document will contain:
+
+```markdown
+---
+tags: foo
+---
+```
+
+##### Array as Path
+
+In the example above, the prompt is being used to assign a [categorical tag](#informational-structure) to the document. In this case we actually want to append the answer value as an element in an array rather than setting the value of the key to a single string.
+
+In this case we must instead set the property [to `"/tags/-"`](https://datatracker.ietf.org/doc/html/rfc6901#:~:text=exactly%20the%20single%20character%20%22%2D%22):
+
+```text
+frontMatterPath: "/tags/-"
+```
+
+If the user answers "**Foo**" to the "**Some tag:**" prompt, the front matter in the generated document will contain:
 
 ```markdown
 ---

--- a/docs/acknowledgments.md
+++ b/docs/acknowledgments.md
@@ -90,4 +90,5 @@ Information that has been invaluable in the development of this project:
 
 - [**How to Write a Git Commit Message**](https://cbea.ms/git-commit/)
 - [**EditorConfig Specification**](https://editorconfig.org/)
+- [**MDN JavaScript Reference**](https://developer.mozilla.org/docs/Web/JavaScript/Reference)
 - [**Semantic Versioning Specification**](https://semver.org/)


### PR DESCRIPTION
The primary use case for the generator's front matter document generation feature is assigning tags to documents based on the prompt answers. The standard is to assign tags as an array of strings under the `tags` front matter key. So it will be essential for the user to understand how to target an array using the `frontMatterPath` prompt data property.

The JSON pointer syntax provides the ability to append an element to an array. This syntax is not intuitive and the documentation of the syntax in [the specification](https://datatracker.ietf.org/doc/html/rfc6901) is not easy to find. So it will be useful for the subject to be explained in the generator's documentation.