### PR TITLE
Merge answer arrays into existing front matter instead of overwriting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,38 @@ tags:
 ---
 ```
 
+##### Answer Arrays
+
+The [`rawlist` **Inquirer** prompt type](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/rawlist#inquirerrawlist) allows the user to select multiple answers from the prompt. For this reason, it produces an array of answer values rather than a single value as is done by other prompt types.
+
+In this case if we used `/tags/-` as in [the above example](#array-as-path) (which is appropriate for prompt types that produce a single answer value), we would end up appending the array of answers as an element in the `tags` array, giving an unintended front matter data structure like this:
+
+```markdown
+---
+tags:
+  - - foo
+    - bar
+---
+```
+
+The intended data structure will be obtained by instead specifying the target key:
+
+```text
+frontMatterPath: "/tags"
+```
+
+Which will result in the front matter in the generated document having a structure like this:
+
+```markdown
+---
+tags:
+  - foo
+  - bar
+---
+```
+
+Just as with the single answer prompts, the answers from prompts that produce an array of answers will be merged into any existing data that was added to the front matter by previous prompts.
+
 ---
 
 For a better understanding of the prompts data file format and functionality, see the [**Example** section](#generator-example).

--- a/app/index.js
+++ b/app/index.js
@@ -135,13 +135,24 @@ export default class extends Generator {
       this.#promptsData.forEach((promptData) => {
         // Determine whether this is the prompt data for the answer.
         if (answerKey === promptData.inquirer.name) {
-          const answerValue = this.#answers[answerKey];
+          let answerValue = this.#answers[answerKey];
 
           if (promptData.usage.includes("content")) {
             this.#templateContext[answerKey] = answerValue;
           }
 
           if (promptData.usage.includes("front matter")) {
+            // Concatenate answer arrays to existing front matter content instead of overwriting.
+            if (Array.isArray(answerValue)) {
+              const frontMatterPathContent = JSONPointer.get(
+                frontMatterObject,
+                promptData.frontMatterPath,
+              );
+              if (Array.isArray(frontMatterPathContent)) {
+                answerValue = frontMatterPathContent.concat(answerValue);
+              }
+            }
+
             JSONPointer.set(
               frontMatterObject,
               promptData.frontMatterPath,

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -165,6 +165,15 @@ describe("running the generator", () => {
       },
     },
     {
+      description: "object prompt with front matter usage, answer array",
+      testdataFolderName: "front-matter-usage-answer-array-prompt-data",
+      answers: {
+        kbDocumentTitle: documentTitle,
+        fooPrompt: "plutoChoice",
+        barPrompt: ["qwerChoice", "zxcvChoice"],
+      },
+    },
+    {
       description: "user prompt with content+front matter usage",
       testdataFolderName: "content-front-matter-usage-prompt-data",
       answers: {

--- a/tests/testdata/front-matter-usage-answer-array-prompt-data/golden/foo-title/doc.md
+++ b/tests/testdata/front-matter-usage-answer-array-prompt-data/golden/foo-title/doc.md
@@ -1,0 +1,8 @@
+---
+tags:
+  - plutoChoice
+  - qwerChoice
+  - zxcvChoice
+---
+
+# Foo Title

--- a/tests/testdata/front-matter-usage-answer-array-prompt-data/primary-document.ejs
+++ b/tests/testdata/front-matter-usage-answer-array-prompt-data/primary-document.ejs
@@ -1,0 +1,3 @@
+<%- kbDocumentFrontMatter %>
+
+# <%- kbDocumentTitle %>

--- a/tests/testdata/front-matter-usage-answer-array-prompt-data/prompts.js
+++ b/tests/testdata/front-matter-usage-answer-array-prompt-data/prompts.js
@@ -1,0 +1,46 @@
+const prompts = [
+  {
+    frontMatterPath: "/tags/-",
+    inquirer: {
+      type: "rawlist",
+      name: "fooPrompt",
+      message: "Foo message:",
+      choices: [
+        {
+          name: "Pippo choice",
+          value: "pippoChoice",
+        },
+        {
+          name: "Pluto choice",
+          value: "plutoChoice",
+        },
+      ],
+    },
+    usage: ["front matter"],
+  },
+  {
+    frontMatterPath: "/tags",
+    inquirer: {
+      type: "checkbox",
+      name: "barPrompt",
+      message: "Bar message:",
+      choices: [
+        {
+          name: "Asdf choice",
+          value: "asdfChoice",
+        },
+        {
+          name: "Qwer choice",
+          value: "qwerChoice",
+        },
+        {
+          name: "Zxcv choice",
+          value: "zxcvChoice",
+        },
+      ],
+    },
+    usage: ["front matter"],
+  },
+];
+
+export default prompts;


### PR DESCRIPTION
Previously, if you had a prompt that returns an answer array, it would overwrite any content of the target front matter path set by previous prompts.

The new behavior is to merge the answers into the existing array (as is already done when working with single answer prompts).