### PR TITLE
Sort front matter data

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ The answer can be referenced by the value from the [`inquirer` object's](#inquir
 
 The answer will be included in the generated front matter document, which can be referenced as `kbDocumentFrontMatter` in the [document file template](#document-file-template). The answers to all prompts with `usage` property that contains `"front matter"` will be merged into the [front matter document](#document-file-template-front-matter).
 
+For information on front matter, see [the **Informational Structure** section](#informational-structure).
+
 ---
 
 ❗ If you include `"front matter"` in the `usage` property, you must also set the [`frontMatterPath` property](#frontmatterpath).

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ The path of the [knowledge base folder](#knowledge-base-structure).
 
 The path of the generator [prompts data file](#prompts-data-file).
 
+#### `sortFrontMatter`
+
+Boolean value to configure whether the items in the [generated front matter document](#front-matter-prompts) should be sorted in lexicographical order.
+
 #### `templatePath`
 
 The path of the knowledge base [document file template](#document-file-template).

--- a/docs/acknowledgments.md
+++ b/docs/acknowledgments.md
@@ -90,5 +90,6 @@ Information that has been invaluable in the development of this project:
 
 - [**How to Write a Git Commit Message**](https://cbea.ms/git-commit/)
 - [**EditorConfig Specification**](https://editorconfig.org/)
+- [**JSON data format overview**](https://www.json.org/json-en.html)
 - [**MDN JavaScript Reference**](https://developer.mozilla.org/docs/Web/JavaScript/Reference)
 - [**Semantic Versioning Specification**](https://semver.org/)

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -181,13 +181,36 @@ describe("running the generator", () => {
         fooPrompt: "plutoChoice",
       },
     },
+    {
+      description: "front matter sorting disabled",
+      testdataFolderName: "unsorted-front-matter",
+      answers: {
+        kbDocumentTitle: documentTitle,
+        fooPrompt: "fooValue",
+        barPrompt: "barValue",
+        bazPrompt: ["qwerChoice", "asdfChoice"],
+      },
+      sortFrontMatter: false,
+    },
+    {
+      description: "front matter sorting enabled",
+      testdataFolderName: "sorted-front-matter",
+      answers: {
+        kbDocumentTitle: documentTitle,
+        fooPrompt: "fooValue",
+        barPrompt: "barValue",
+        bazPrompt: ["qwerChoice", "asdfChoice"],
+      },
+      sortFrontMatter: true,
+    },
   ])(
     "with valid configuration ($description)",
-    ({ testdataFolderName, answers }) => {
+    ({ testdataFolderName, answers, sortFrontMatter }) => {
       const thisTestDataPath = path.join(testDataPath, testdataFolderName);
       const localConfig = {
         kbPath: "kb",
         promptsDataPath: path.join(thisTestDataPath, "prompts.js"),
+        sortFrontMatter,
         templatePath: path.join(thisTestDataPath, "primary-document.ejs"),
       };
       const documentFilePath = path.join(

--- a/tests/testdata/array-path-front-matter-usage-prompt-data/golden/foo-title/doc.md
+++ b/tests/testdata/array-path-front-matter-usage-prompt-data/golden/foo-title/doc.md
@@ -1,7 +1,7 @@
 ---
 tags:
-  - plutoChoice
   - asdfChoice
+  - plutoChoice
 ---
 
 # Foo Title

--- a/tests/testdata/sorted-front-matter/golden/foo-title/doc.md
+++ b/tests/testdata/sorted-front-matter/golden/foo-title/doc.md
@@ -1,0 +1,8 @@
+---
+tags:
+  - asdfChoice
+  - qwerChoice
+zzz:
+  bar: barValue
+  foo: fooValue
+---

--- a/tests/testdata/sorted-front-matter/primary-document.ejs
+++ b/tests/testdata/sorted-front-matter/primary-document.ejs
@@ -1,0 +1,1 @@
+<%- kbDocumentFrontMatter %>

--- a/tests/testdata/sorted-front-matter/prompts.js
+++ b/tests/testdata/sorted-front-matter/prompts.js
@@ -1,0 +1,41 @@
+const prompts = [
+  {
+    frontMatterPath: "/zzz/foo",
+    inquirer: {
+      type: "input",
+      name: "fooPrompt",
+      message: "Foo message:",
+    },
+    usage: ["front matter"],
+  },
+  {
+    frontMatterPath: "/zzz/bar",
+    inquirer: {
+      type: "input",
+      name: "barPrompt",
+      message: "Bar message:",
+    },
+    usage: ["front matter"],
+  },
+  {
+    frontMatterPath: "/tags",
+    inquirer: {
+      type: "checkbox",
+      name: "bazPrompt",
+      message: "Baz message:",
+      choices: [
+        {
+          name: "Qwer choice",
+          value: "qwerChoice",
+        },
+        {
+          name: "Asdf choice",
+          value: "asdfChoice",
+        },
+      ],
+    },
+    usage: ["front matter"],
+  },
+];
+
+export default prompts;

--- a/tests/testdata/unsorted-front-matter/golden/foo-title/doc.md
+++ b/tests/testdata/unsorted-front-matter/golden/foo-title/doc.md
@@ -1,0 +1,8 @@
+---
+zzz:
+  foo: fooValue
+  bar: barValue
+tags:
+  - qwerChoice
+  - asdfChoice
+---

--- a/tests/testdata/unsorted-front-matter/primary-document.ejs
+++ b/tests/testdata/unsorted-front-matter/primary-document.ejs
@@ -1,0 +1,1 @@
+<%- kbDocumentFrontMatter %>

--- a/tests/testdata/unsorted-front-matter/prompts.js
+++ b/tests/testdata/unsorted-front-matter/prompts.js
@@ -1,0 +1,41 @@
+const prompts = [
+  {
+    frontMatterPath: "/zzz/foo",
+    inquirer: {
+      type: "input",
+      name: "fooPrompt",
+      message: "Foo message:",
+    },
+    usage: ["front matter"],
+  },
+  {
+    frontMatterPath: "/zzz/bar",
+    inquirer: {
+      type: "input",
+      name: "barPrompt",
+      message: "Bar message:",
+    },
+    usage: ["front matter"],
+  },
+  {
+    frontMatterPath: "/tags",
+    inquirer: {
+      type: "checkbox",
+      name: "bazPrompt",
+      message: "Baz message:",
+      choices: [
+        {
+          name: "Qwer choice",
+          value: "qwerChoice",
+        },
+        {
+          name: "Asdf choice",
+          value: "asdfChoice",
+        },
+      ],
+    },
+    usage: ["front matter"],
+  },
+];
+
+export default prompts;


### PR DESCRIPTION
Previously, the front matter data was ordered according to the prompts data file. Although the order is not likely of importance to a machine consumer of the front matter data, a human will find it easier to read and maintain the front matter if it is sorted in lexicographical order.

In case some users might prefer the sorting left according to the prompts data file, an option is added to the generator configuration file for disabling this feature.