### PR TITLE
Provide a description for the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@per1234/generator-kb-document",
+  "description": "Yeoman generator for creating documents in a Markdown file-based knowledge base.",
   "version": "0.1.0-beta",
   "dependencies": {
     "ajv": "8.17.1",


### PR DESCRIPTION
The value of the package.json `description` key is displayed by npm and the npm package registry in several places:

- `npm search` command output
- `npm view` command output
- The npm package registry website search

If the field is not present, the start of the readme is used as a fallback.

Although we might hope that would make the `description` field superfluous, making it possible to avoid the burden of maintaining yet another thing in the project, unfortunately in practice the readme content doesn't serve as a suitable replacement for the `description` field. The reason is that the readme starts with a collection of badges to indicate the status of the project's GitHub Actions workflow runs. That is appropriate when viewing the readme as a whole (as we do on GitHub, on the package's page on the npm registry, and when viewing the file locally), but it is not appropriate in the contexts where the `description` field is used. The reason is that, in these contexts, only a small amount of text is shown, and also the markup is not rendered. So you just see a snippet of meaningless badge markup as the package description instead of something that actually communicates the purpose of the package to the reader. For example:

![image](https://github.com/user-attachments/assets/3a11e2c9-2009-4a3b-bc70-8a7bb7ad862d)
