### PR TITLE
Add support for configuring universal front matter

### DIFF
--- a/.github/workflows/test-javascript-jest-task.yml
+++ b/.github/workflows/test-javascript-jest-task.yml
@@ -7,6 +7,7 @@ on:
       - ".github/workflows/test-javascript-jest-task.ya?ml"
       - ".github/.?codecov.ya?ml"
       - "dev/.?codecov.ya?ml"
+      - "etc/generator-kb-document-prompts-data-schema.json"
       - ".?codecov.ya?ml"
       - "**/jest.config.[cm]?js"
       - "**/jest.config.json"
@@ -14,6 +15,7 @@ on:
       - "**/package.json"
       - "**/package-lock.json"
       - "Taskfile.ya?ml"
+      - "tests/testdata/**"
       - "**/tsconfig.json"
       - "**.[jt]sx?"
   pull_request:
@@ -21,6 +23,7 @@ on:
       - ".github/workflows/test-javascript-jest-task.ya?ml"
       - ".github/.?codecov.ya?ml"
       - "dev/.?codecov.ya?ml"
+      - "etc/generator-kb-document-prompts-data-schema.json"
       - ".?codecov.ya?ml"
       - "**/jest.config.[cm]?js"
       - "**/jest.config.json"
@@ -28,6 +31,7 @@ on:
       - "**/package.json"
       - "**/package-lock.json"
       - "Taskfile.ya?ml"
+      - "tests/testdata/**"
       - "**/tsconfig.json"
       - "**.[jt]sx?"
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ If a prompt defined in the [prompts data file](#prompts-data-file) has `"content
 
 ##### `"front matter"` Prompts
 
-If a prompt defined in the [prompts data file](#prompts-data-file) which has `"front matter"` in its [`usage`](#prompt-data-usage-property) property, its answer will be included in a single generated front matter document. That front matter document is available for use in the template via the `kbDocumentFrontMatter` variable:
+If a prompt defined in the [prompts data file](#prompts-data-file) has `"front matter"` in its [`usage`](#prompt-data-usage-property) property, its answer will be included in a single generated front matter document. That front matter document is available for use in the template via the `kbDocumentFrontMatter` variable:
 
 ```ejs
 <%- kbDocumentFrontMatter %>

--- a/README.md
+++ b/README.md
@@ -67,11 +67,37 @@ The path of the generator [prompts data file](#prompts-data-file).
 
 #### `sortFrontMatter`
 
-Boolean value to configure whether the items in the [generated front matter document](#front-matter-prompts) should be sorted in lexicographical order.
+Boolean value to configure whether the items in the [generated front matter document](#front-matter) should be sorted in lexicographical order.
 
 #### `templatePath`
 
 The path of the knowledge base [document file template](#document-file-template).
+
+#### `universalFrontMatter`
+
+Object defining data that should be added to the front matter of every document the generator creates.
+
+For example, if you set the `universalFrontMatter` like so:
+
+```text
+"universalFrontMatter": {
+  "foo": "bar"
+}
+```
+
+The front matter document available for use in your template via the [`kbDocumentFrontMatter` variable](#front-matter) will contain this content:
+
+```text
+---
+foo: bar
+<...>
+```
+
+This is static data. An example usage would be configuring tools that consume Markdown files and recognize special front matter keys.
+
+You can also use the [**prompts data file**](#prompts-data-file) to configure prompts so that front matter data will be set according to the answers provided during the document creation process.
+
+For information on front matter, see [the **Informational Structure** section](#informational-structure).
 
 ### Prompts Data File
 
@@ -308,9 +334,14 @@ If a prompt defined in the [prompts data file](#prompts-data-file) has `"content
 
 <a name="document-file-template-front-matter"></a>
 
-##### `"front matter"` Prompts
+##### Front Matter
 
-If a prompt defined in the [prompts data file](#prompts-data-file) has `"front matter"` in its [`usage`](#prompt-data-usage-property) property, its answer will be included in a single generated front matter document. That front matter document is available for use in the template via the `kbDocumentFrontMatter` variable:
+Front matter data can come from two sources:
+
+- The `universalFrontMatter` key in the [**generator configuration file**](#generator-configuration-file).
+- Prompts defined in the [**prompts data file**](#prompts-data-file) that have `"front matter"` in their [`usage`](#prompt-data-usage-property) property.
+
+This data is used to populate a single generated front matter document. That front matter document is available for use in the template via the `kbDocumentFrontMatter` variable:
 
 ```ejs
 <%- kbDocumentFrontMatter %>

--- a/app/index.js
+++ b/app/index.js
@@ -50,6 +50,7 @@ export default class extends Generator {
   initializing() {
     this.config.defaults({
       sortFrontMatter: true,
+      universalFrontMatter: {},
     });
 
     // Validate configuration.
@@ -164,7 +165,7 @@ export default class extends Generator {
   configuring() {
     // Process answers
     this.#templateContext = [];
-    let frontMatterObject = {};
+    let frontMatterObject = this.config.get("universalFrontMatter");
     Object.keys(this.#answers).forEach((answerKey) => {
       this.#promptsData.forEach((promptData) => {
         // Determine whether this is the prompt data for the answer.

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -203,15 +203,32 @@ describe("running the generator", () => {
       },
       sortFrontMatter: true,
     },
+    {
+      description: "universal front matter",
+      testdataFolderName: "universalFrontMatter",
+      answers: {
+        kbDocumentTitle: documentTitle,
+        fooPrompt: "fooValue",
+      },
+      universalFrontMatter: {
+        foo: "bar",
+      },
+    },
   ])(
     "with valid configuration ($description)",
-    ({ testdataFolderName, answers, sortFrontMatter }) => {
+    ({
+      testdataFolderName,
+      answers,
+      sortFrontMatter,
+      universalFrontMatter,
+    }) => {
       const thisTestDataPath = path.join(testDataPath, testdataFolderName);
       const localConfig = {
         kbPath: "kb",
         promptsDataPath: path.join(thisTestDataPath, "prompts.js"),
         sortFrontMatter,
         templatePath: path.join(thisTestDataPath, "primary-document.ejs"),
+        universalFrontMatter,
       };
       const documentFilePath = path.join(
         localConfig.kbPath,

--- a/tests/testdata/universalFrontMatter/golden/foo-title/doc.md
+++ b/tests/testdata/universalFrontMatter/golden/foo-title/doc.md
@@ -1,0 +1,5 @@
+---
+foo: bar
+tags:
+  - fooValue
+---

--- a/tests/testdata/universalFrontMatter/primary-document.ejs
+++ b/tests/testdata/universalFrontMatter/primary-document.ejs
@@ -1,0 +1,1 @@
+<%- kbDocumentFrontMatter %>

--- a/tests/testdata/universalFrontMatter/prompts.js
+++ b/tests/testdata/universalFrontMatter/prompts.js
@@ -1,0 +1,13 @@
+const prompts = [
+  {
+    frontMatterPath: "/tags/-",
+    inquirer: {
+      type: "input",
+      name: "fooPrompt",
+      message: "Foo message:",
+    },
+    usage: ["front matter"],
+  },
+];
+
+export default prompts;


### PR DESCRIPTION
In addition to the per-document front matter data configured by the prompt answers, it is sometimes necessary to add some static data to the front matter of every document.

The generator now supports the configuration of such "universal" front matter via the generator configuration file.