### PR TITLE
Add answer processor feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Project website: https://github.com/per1234/generator-kb-document
     - [`inquirer`](#inquirer)
     - [`usage`](#usage)
     - [`frontMatterPath`](#frontmatterpath)
+    - [`processors`](#processors)
   - [Document File Template](#document-file-template)
     - [Document Title](#document-title)
     - [Prompts from Prompts Data File](#prompts-from-prompts-data-file)
@@ -280,7 +281,7 @@ tags:
 
 ##### Answer Arrays
 
-The [`rawlist` **Inquirer** prompt type](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/rawlist#inquirerrawlist) allows the user to select multiple answers from the prompt. For this reason, it produces an array of answer values rather than a single value as is done by other prompt types.
+The [`rawlist` **Inquirer** prompt type](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/rawlist#inquirerrawlist) allows the user to select multiple answers from the prompt. For this reason, it produces an array of answer values rather than a single value as is done by other prompt types. Arrays of answer values are also produced by the [`csv` processor](#processor-csv
 
 In this case if we used `/tags/-` as in [the above example](#array-as-path) (which is appropriate for prompt types that produce a single answer value), we would end up appending the array of answers as an element in the `tags` array, giving an unintended front matter data structure like this:
 
@@ -319,6 +320,48 @@ For a better understanding of the prompts data file format and functionality, se
 **ⓘ** A [JSON schema](https://json-schema.org/) for validation of the prompts data is provided [**here**](etc/generator-kb-document-prompts-data-schema.json).
 
 ---
+
+#### `processors`
+
+**Default value:** `[]`
+
+The `processors` property is an array of processor configuration objects which specify optional processing operations that should be performed on the answer to the prompt before making making the value available for use in the [document file template](#document-file-template):
+
+```text
+{
+  inquirer: {
+    <Inquirer Question object>
+  },
+  usage: [
+    "content"
+  ],
+  processors: [
+    {
+      <processor configuration object>
+    },
+  ],
+  <...>
+}
+```
+
+The processing operations will be applied in sequence, following the order from the `processors` array.
+
+##### `processor: "csv"`
+
+It may be necessary for a single prompt to accept multiple answer values. When the set of possible answer values is fixed, the [`checkbox` prompt type](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/checkbox#inquirercheckbox) can be used to handle this nicely, outputting an array of answers. Unfortunately **Inquirer** doesn't provide any equivalent prompt type for accepting multiple free text answer values. In this case, the best solution will be to use the [`input` prompt type](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/input#inquirerinput) and pass the set of values in a string that has a delimiter-separated format (commonly referred to as [CSV](https://en.wikipedia.org/wiki/Comma-separated_values)).
+
+###### `delimiter`
+
+**Default value:** `","`
+
+This processor converts the string answer value to an array by splitting it on delimiters. The delimiter can be configured via the processor configuration object's `delimiter` property:
+
+```text
+{
+  processor: "csv",
+  delimiter: ",",
+}
+```
 
 ### Document File Template
 

--- a/app/index.js
+++ b/app/index.js
@@ -172,6 +172,35 @@ export default class extends Generator {
         if (answerKey === promptData.inquirer.name) {
           let answerValue = this.#answers[answerKey];
 
+          if ("processors" in promptData) {
+            promptData.processors.forEach((processor) => {
+              switch (processor.name) {
+                case "csv": {
+                  let delimiter = ",";
+                  if ("delimiter" in processor) {
+                    delimiter = processor.delimiter;
+                  }
+
+                  // `String.prototype.split()` returns a single element array if it is an empty string:
+                  // https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/split#using_split
+                  if (answerValue !== undefined && answerValue !== "") {
+                    answerValue = answerValue.split(delimiter);
+                  } else {
+                    answerValue = [];
+                  }
+
+                  break;
+                }
+                // This case can never be reached under normal operation because valid processor values are enforced by
+                // the prompts data validation.
+                /* istanbul ignore next */
+                default: {
+                  throw new Error(`Unknown processor ${processor.name}`);
+                }
+              }
+            });
+          }
+
           if (promptData.usage.includes("content")) {
             this.#templateContext[answerKey] = answerValue;
           }

--- a/app/index.js
+++ b/app/index.js
@@ -234,7 +234,6 @@ export default class extends Generator {
 
     // Generate front matter.
     const frontMatterString = yamlStringify(frontMatterObject, null, {
-      collectionStyle: "block",
       directives: false,
     });
     // Markdown front matter is wrapped in YAML "directives end markers". The `yaml` package doesn't provide a clean way

--- a/etc/generator-kb-document-prompts-data-schema.json
+++ b/etc/generator-kb-document-prompts-data-schema.json
@@ -22,6 +22,26 @@
       "frontMatterPath": {
         "type": "string",
         "minLength": 2
+      },
+      "processing": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "oneOf": [
+            {
+              "properties": {
+                "name": {
+                  "const": "csv"
+                },
+                "delimiter": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": ["name"]
+            }
+          ]
+        }
       }
     },
     "required": ["inquirer", "usage"]

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -214,6 +214,31 @@ describe("running the generator", () => {
         foo: "bar",
       },
     },
+    {
+      description: "csv processor",
+      testdataFolderName: "csv-processor",
+      answers: {
+        kbDocumentTitle: documentTitle,
+        fooPrompt: "barValue,fooValue",
+      },
+    },
+    {
+      description: "csv processor, default delimiter",
+      testdataFolderName: "csv-processor-default-delimiter",
+      answers: {
+        kbDocumentTitle: documentTitle,
+        fooPrompt: "barValue,fooValue",
+      },
+    },
+    {
+      description: "csv processor, empty answer",
+      testdataFolderName: "csv-processor-empty-answer",
+      answers: {
+        kbDocumentTitle: documentTitle,
+        barPrompt: "barValue",
+        fooPrompt: "",
+      },
+    },
   ])(
     "with valid configuration ($description)",
     ({

--- a/tests/testdata/csv-processor-default-delimiter/golden/foo-title/doc.md
+++ b/tests/testdata/csv-processor-default-delimiter/golden/foo-title/doc.md
@@ -1,0 +1,5 @@
+---
+tags:
+  - barValue
+  - fooValue
+---

--- a/tests/testdata/csv-processor-default-delimiter/primary-document.ejs
+++ b/tests/testdata/csv-processor-default-delimiter/primary-document.ejs
@@ -1,0 +1,1 @@
+<%- kbDocumentFrontMatter %>

--- a/tests/testdata/csv-processor-default-delimiter/prompts.js
+++ b/tests/testdata/csv-processor-default-delimiter/prompts.js
@@ -1,0 +1,18 @@
+const prompts = [
+  {
+    frontMatterPath: "/tags",
+    inquirer: {
+      type: "input",
+      name: "fooPrompt",
+      message: "Foo message:",
+    },
+    processors: [
+      {
+        name: "csv",
+      },
+    ],
+    usage: ["front matter"],
+  },
+];
+
+export default prompts;

--- a/tests/testdata/csv-processor-empty-answer/golden/foo-title/doc.md
+++ b/tests/testdata/csv-processor-empty-answer/golden/foo-title/doc.md
@@ -1,0 +1,4 @@
+---
+bar: barValue
+tags: []
+---

--- a/tests/testdata/csv-processor-empty-answer/primary-document.ejs
+++ b/tests/testdata/csv-processor-empty-answer/primary-document.ejs
@@ -1,0 +1,1 @@
+<%- kbDocumentFrontMatter %>

--- a/tests/testdata/csv-processor-empty-answer/prompts.js
+++ b/tests/testdata/csv-processor-empty-answer/prompts.js
@@ -1,0 +1,28 @@
+const prompts = [
+  {
+    frontMatterPath: "/bar",
+    inquirer: {
+      type: "input",
+      name: "barPrompt",
+      message: "Bar message:",
+    },
+    usage: ["front matter"],
+  },
+  {
+    frontMatterPath: "/tags",
+    inquirer: {
+      type: "input",
+      name: "fooPrompt",
+      message: "Foo message:",
+    },
+    processors: [
+      {
+        name: "csv",
+        delimiter: ",",
+      },
+    ],
+    usage: ["front matter"],
+  },
+];
+
+export default prompts;

--- a/tests/testdata/csv-processor/golden/foo-title/doc.md
+++ b/tests/testdata/csv-processor/golden/foo-title/doc.md
@@ -1,0 +1,5 @@
+---
+tags:
+  - barValue
+  - fooValue
+---

--- a/tests/testdata/csv-processor/primary-document.ejs
+++ b/tests/testdata/csv-processor/primary-document.ejs
@@ -1,0 +1,1 @@
+<%- kbDocumentFrontMatter %>

--- a/tests/testdata/csv-processor/prompts.js
+++ b/tests/testdata/csv-processor/prompts.js
@@ -1,0 +1,19 @@
+const prompts = [
+  {
+    frontMatterPath: "/tags",
+    inquirer: {
+      type: "input",
+      name: "fooPrompt",
+      message: "Foo message:",
+    },
+    processors: [
+      {
+        name: "csv",
+        delimiter: ",",
+      },
+    ],
+    usage: ["front matter"],
+  },
+];
+
+export default prompts;


### PR DESCRIPTION
In some cases, it is necessary to make some transformations on the prompt answer value in order to make it suitable for use in the document. This can be done in the template code, but this means the often complex EJS code must be written and maintained in each knowledge base project. It will be more convenient for each of the commonly needed processing operations to be implemented in the generator code instead.