### PR TITLE
Trim whitespace from answer values

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -172,6 +172,11 @@ export default class extends Generator {
         if (answerKey === promptData.inquirer.name) {
           let answerValue = this.#answers[answerKey];
 
+          // Trim whitespace from string values.
+          if (typeof answerValue === "string") {
+            answerValue = answerValue.trim();
+          }
+
           if ("processors" in promptData) {
             promptData.processors.forEach((processor) => {
               switch (processor.name) {
@@ -185,6 +190,9 @@ export default class extends Generator {
                   // https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/split#using_split
                   if (answerValue !== undefined && answerValue !== "") {
                     answerValue = answerValue.split(delimiter);
+
+                    // Trim whitespace from elements.
+                    answerValue = answerValue.map((element) => element.trim());
                   } else {
                     answerValue = [];
                   }
@@ -241,9 +249,6 @@ export default class extends Generator {
     const frontMatterDocument = `---\n${frontMatterString}---`;
     // Make front matter available for use in the document template.
     this.#templateContext.kbDocumentFrontMatter = frontMatterDocument;
-
-    // Trim whitespace from free text inputs.
-    this.#answers.kbDocumentTitle = this.#answers.kbDocumentTitle.trim();
 
     // Determine path for generated file.
     const documentFolderName = slug(this.#answers.kbDocumentTitle);


### PR DESCRIPTION
When the generator user is entering free text at the prompts in the terminal, it is fairly easy to accidentally introduce leading or trailing whitespace. This will then cause poor formatting in the created KB document. So it will be helpful for the generator to trim the strings.

Although this could be implemented as a user-controlled processor, I can't imagine any use case where the user would actually want to preserve leading or trailing whitespace in answers so I chose to just hardcode the behavior into the generator.

The ability to programmatically add content (which can include whitespace) to answers will be provided via a "template" answer processor.