### PR TITLE
Use "processor" as processor ID key

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -179,7 +179,7 @@ export default class extends Generator {
 
           if ("processors" in promptData) {
             promptData.processors.forEach((processor) => {
-              switch (processor.name) {
+              switch (processor.processor) {
                 case "csv": {
                   let delimiter = ",";
                   if ("delimiter" in processor) {
@@ -203,7 +203,7 @@ export default class extends Generator {
                 // the prompts data validation.
                 /* istanbul ignore next */
                 default: {
-                  throw new Error(`Unknown processor ${processor.name}`);
+                  throw new Error(`Unknown processor ${processor.processor}`);
                 }
               }
             });

--- a/etc/generator-kb-document-prompts-data-schema.json
+++ b/etc/generator-kb-document-prompts-data-schema.json
@@ -30,7 +30,7 @@
           "oneOf": [
             {
               "properties": {
-                "name": {
+                "processor": {
                   "const": "csv"
                 },
                 "delimiter": {
@@ -38,7 +38,7 @@
                   "minLength": 1
                 }
               },
-              "required": ["name"]
+              "required": ["processor"]
             }
           ]
         }

--- a/tests/testdata/csv-processor-default-delimiter/prompts.js
+++ b/tests/testdata/csv-processor-default-delimiter/prompts.js
@@ -8,7 +8,7 @@ const prompts = [
     },
     processors: [
       {
-        name: "csv",
+        processor: "csv",
       },
     ],
     usage: ["front matter"],

--- a/tests/testdata/csv-processor-empty-answer/prompts.js
+++ b/tests/testdata/csv-processor-empty-answer/prompts.js
@@ -17,7 +17,7 @@ const prompts = [
     },
     processors: [
       {
-        name: "csv",
+        processor: "csv",
         delimiter: ",",
       },
     ],

--- a/tests/testdata/csv-processor/prompts.js
+++ b/tests/testdata/csv-processor/prompts.js
@@ -8,7 +8,7 @@ const prompts = [
     },
     processors: [
       {
-        name: "csv",
+        processor: "csv",
         delimiter: ",",
       },
     ],


### PR DESCRIPTION
Previously, the code used the key `name`, while the documentation specified `processor`.

The code is hereby changed to match the documentation.