### PR TITLE
Use appropriate prompt type in "sort processor" test data

### DIFF
--- a/tests/testdata/sort-processor/prompts.js
+++ b/tests/testdata/sort-processor/prompts.js
@@ -1,7 +1,7 @@
 const prompts = [
   {
     inquirer: {
-      type: "rawlist",
+      type: "checkbox",
       name: "fooPrompt",
       message: "Foo message:",
       choices: [


### PR DESCRIPTION
The "sort processor" test provides multiple answer values to the prompt. Previously, due to a copy/paste error, the prompt type specified in the prompt data was `rawlist`. When using the generator from a terminal, this prompt type only allows the selection of a single choice, which made it inappropriate for this test. Evidently it is still possible to provide an array of answer values via the test API, but there is no guarantee that will continue to work.

The test data is hereby updated to use the appropriate prompt type for accepting multiple answer values for a prompt: `checkbox`.