### PR TITLE
Apply "template" processor to elements of answer arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,8 @@ The answer value is available for referencing in the template as `answer`.
 }
 ```
 
+When the input is an [answer array](#configuration-answer-arrays), the processor transforms each of the elements in the array.
+
 #### JSON Schema
 
 A [JSON schema](https://json-schema.org/) for validation of the prompts data is provided [**here**](etc/generator-kb-document-prompts-data-schema.json).

--- a/app/index.js
+++ b/app/index.js
@@ -221,7 +221,13 @@ export default class extends Generator {
                   }
 
                   try {
-                    answerValue = compiledTemplate({ answer: answerValue });
+                    if (Array.isArray(answerValue)) {
+                      answerValue = answerValue.map((answerValueElement) =>
+                        compiledTemplate({ answer: answerValueElement }),
+                      );
+                    } else {
+                      answerValue = compiledTemplate({ answer: answerValue });
+                    }
                   } catch (error) {
                     throw new Error(
                       `Failed to expand template for "${answerKey}" prompt answer:\n${error}`,

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -332,6 +332,14 @@ describe("running the generator", () => {
         fooPrompt: "fooValue",
       },
     },
+    {
+      description: "template processor, answer array",
+      testdataFolderName: "template-processor-answer-array",
+      answers: {
+        kbDocumentTitle: documentTitle,
+        fooPrompt: ["pippoChoice", "plutoChoice"],
+      },
+    },
   ])(
     "with valid configuration ($description)",
     ({

--- a/tests/testdata/template-processor-answer-array/golden/foo-title/doc.md
+++ b/tests/testdata/template-processor-answer-array/golden/foo-title/doc.md
@@ -1,0 +1,2 @@
+- The answer value is pippoChoice
+- The answer value is plutoChoice

--- a/tests/testdata/template-processor-answer-array/primary-document.ejs
+++ b/tests/testdata/template-processor-answer-array/primary-document.ejs
@@ -1,0 +1,3 @@
+<% fooPrompt.forEach((element) => { -%>
+<%- element %>
+<% }); -%>

--- a/tests/testdata/template-processor-answer-array/prompts.js
+++ b/tests/testdata/template-processor-answer-array/prompts.js
@@ -1,0 +1,28 @@
+const prompts = [
+  {
+    inquirer: {
+      type: "checkbox",
+      name: "fooPrompt",
+      message: "Foo message:",
+      choices: [
+        {
+          name: "Pippo choice",
+          value: "pippoChoice",
+        },
+        {
+          name: "Pluto choice",
+          value: "plutoChoice",
+        },
+      ],
+    },
+    processors: [
+      {
+        processor: "template",
+        template: "- The answer value is <%- answer %>",
+      },
+    ],
+    usage: ["content"],
+  },
+];
+
+export default prompts;


### PR DESCRIPTION
Some prompt configurations result in an array of answers.

Previously, the "template" processor always applied the template directly to the answer. That approach caused it to not be of use with answer arrays.

The processor is made useful for answer arrays by applying the template to each of the elements of the array.