### PR TITLE
Add missing coverage for processor to prompts data JSON schema

### DIFF
--- a/etc/generator-kb-document-prompts-data-schema.json
+++ b/etc/generator-kb-document-prompts-data-schema.json
@@ -43,6 +43,17 @@
             {
               "properties": {
                 "processor": {
+                  "const": "join"
+                },
+                "separator": {
+                  "type": "string"
+                }
+              },
+              "required": ["processor"]
+            },
+            {
+              "properties": {
+                "processor": {
                   "const": "sort"
                 }
               },

--- a/etc/generator-kb-document-prompts-data-schema.json
+++ b/etc/generator-kb-document-prompts-data-schema.json
@@ -54,6 +54,17 @@
             {
               "properties": {
                 "processor": {
+                  "const": "kb-link"
+                },
+                "separator": {
+                  "type": "string"
+                }
+              },
+              "required": ["processor"]
+            },
+            {
+              "properties": {
+                "processor": {
                   "const": "sort"
                 }
               },


### PR DESCRIPTION
I forgot to add this when I implemented these processors.