### PR TITLE
Configure prompts data JSON schema to disallow unknown properties

### DIFF
--- a/etc/generator-kb-document-prompts-data-schema.json
+++ b/etc/generator-kb-document-prompts-data-schema.json
@@ -6,6 +6,7 @@
   "type": "array",
   "items": {
     "type": "object",
+    "additionalProperties": false,
     "properties": {
       "inquirer": {
         "type": "object"
@@ -38,6 +39,7 @@
           "type": "object",
           "oneOf": [
             {
+              "additionalProperties": false,
               "properties": {
                 "processor": {
                   "const": "csv"
@@ -50,6 +52,7 @@
               "required": ["processor"]
             },
             {
+              "additionalProperties": false,
               "properties": {
                 "processor": {
                   "const": "join"
@@ -61,6 +64,7 @@
               "required": ["processor"]
             },
             {
+              "additionalProperties": false,
               "properties": {
                 "processor": {
                   "const": "kb-link"
@@ -72,6 +76,7 @@
               "required": ["processor"]
             },
             {
+              "additionalProperties": false,
               "properties": {
                 "processor": {
                   "const": "sort"
@@ -80,6 +85,7 @@
               "required": ["processor"]
             },
             {
+              "additionalProperties": false,
               "properties": {
                 "processor": {
                   "const": "template"


### PR DESCRIPTION
There is no good reason for a user to add properties to their prompts data file other than the ones used by the generator. The presence of unknown properties indicates an error and thus should cause the prompts data validation to fail.