### PR TITLE
Remove incorrect kb-link processor companion property from prompt data JSON schema

### DIFF
--- a/etc/generator-kb-document-prompts-data-schema.json
+++ b/etc/generator-kb-document-prompts-data-schema.json
@@ -68,9 +68,6 @@
               "properties": {
                 "processor": {
                   "const": "kb-link"
-                },
-                "separator": {
-                  "type": "string"
                 }
               },
               "required": ["processor"]


### PR DESCRIPTION
Previously, due to a copy/paste error, the prompt data JSON schema was configured for the kb-link processor configuration to have a `separator` property. The processor doesn't have any such property so it is removed from the schema.