### PR TITLE
Assign prompts data to class property as early as possible in generator code

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -135,6 +135,8 @@ export default class extends Generator {
         );
       }
 
+      this.#promptsData = promptsData.default;
+
       // Validate prompts data format.
       // Validation using JSON schema.
       const moduleFilePath = fileURLToPath(import.meta.url);
@@ -150,7 +152,7 @@ export default class extends Generator {
       const ajv = new Ajv();
       const schemaValidator = ajv.compile(schema);
 
-      const valid = schemaValidator(promptsData.default);
+      const valid = schemaValidator(this.#promptsData);
       if (!valid) {
         const validationErrors = JSON.stringify(
           schemaValidator.errors,
@@ -167,7 +169,7 @@ export default class extends Generator {
       // Perform additional validations that are not possible via the JSON schema.
       let missingFrontMatterPath = false;
       let missingFrontMatterPathName = "";
-      promptsData.default.forEach((promptData) => {
+      this.#promptsData.forEach((promptData) => {
         if (
           promptData.usages.includes("front matter") &&
           !("frontMatterPath" in promptData)
@@ -186,7 +188,7 @@ export default class extends Generator {
       }
 
       // Use defaults for prompt data properties not set by user in prompts data file.
-      this.#promptsData = promptsData.default.map((promptData) => {
+      this.#promptsData = this.#promptsData.map((promptData) => {
         const promptDataWithDefaults = {
           ...promptDataDefaults,
           ...promptData,

--- a/app/index.js
+++ b/app/index.js
@@ -185,7 +185,6 @@ export default class extends Generator {
         );
       }
 
-      this.#promptsData = promptsData.default;
       // Use defaults for prompt data properties not set by user in prompts data file.
       this.#promptsData = promptsData.default.map((promptData) => {
         const promptDataWithDefaults = {


### PR DESCRIPTION
Previously, the prompts data was only stored in the dedicated class property at the end of the `initializing` function.

The code before the assignment accessed the data via a local variable, while all the code after accessed it via the dedicated class property.

This made the code difficult to follow and bugs easy to introduce. That is avoided by assigning the property as early as possible, then using it exclusively in all the rest of the code.