### PR TITLE
Set prompts data defaults before performing additional validations

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -166,27 +166,6 @@ export default class extends Generator {
         );
       }
 
-      // Perform additional validations that are not possible via the JSON schema.
-      let missingFrontMatterPath = false;
-      let missingFrontMatterPathName = "";
-      this.#promptsData.forEach((promptData) => {
-        if (
-          promptData.usages.includes("front matter") &&
-          !("frontMatterPath" in promptData)
-        ) {
-          missingFrontMatterPath = true;
-          missingFrontMatterPathName = promptData.inquirer.name;
-        }
-      });
-
-      if (missingFrontMatterPath) {
-        return Promise.reject(
-          new Error(
-            `Data for ${missingFrontMatterPathName} prompt has "front matter" usage configuration, but missing frontMatterPath property.`,
-          ),
-        );
-      }
-
       // Use defaults for prompt data properties not set by user in prompts data file.
       this.#promptsData = this.#promptsData.map((promptData) => {
         const promptDataWithDefaults = {
@@ -216,6 +195,27 @@ export default class extends Generator {
 
         return promptDataWithDefaults;
       });
+
+      // Perform additional validations that are not possible via the JSON schema.
+      let missingFrontMatterPath = false;
+      let missingFrontMatterPathName = "";
+      this.#promptsData.forEach((promptData) => {
+        if (
+          promptData.usages.includes("front matter") &&
+          !("frontMatterPath" in promptData)
+        ) {
+          missingFrontMatterPath = true;
+          missingFrontMatterPathName = promptData.inquirer.name;
+        }
+      });
+
+      if (missingFrontMatterPath) {
+        return Promise.reject(
+          new Error(
+            `Data for ${missingFrontMatterPathName} prompt has "front matter" usage configuration, but missing frontMatterPath property.`,
+          ),
+        );
+      }
 
       return Promise.resolve();
     });


### PR DESCRIPTION
The generator performs various validations on the user's prompt data file. Previously these were all performed before applying the defaults to the data. It is best to perform the basic data structure validations on the user's data alone, but when it comes to the additional more complex validations, where the requirements on one property are dependency on another property, the correct validation result might only be obtained after the defaults are applied.

For this reason, the additional validation code is moved to after the code that sets the defaults.