### PR TITLE
Display a user friendly error when generator configuration is missing

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -83,6 +83,17 @@ export default class extends Generator {
     ];
 
     this.#generatorConfiguration = this.config.getAll();
+
+    // Provide a user friendly message if the generator configuration is missing.
+    // this.config.getAll() always returns an object so empty object is used as indicator of missing generator config.
+    if (Object.keys(this.#generatorConfiguration).length === 0) {
+      return Promise.reject(
+        new Error(
+          "Missing generator configuration.\nSee: https://github.com/per1234/generator-kb-document#generator-configuration-file",
+        ),
+      );
+    }
+
     // Validate generator configuration data format against JSON schema.
     const moduleFilePath = fileURLToPath(import.meta.url);
     const moduleFolderPath = path.dirname(moduleFilePath);

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -30,6 +30,14 @@ afterAll(async () => {
 });
 
 describe("invalid configuration", () => {
+  // The test table does not accommodate this test so it is implemented independently.
+  describe("missing generator configuration", () => {
+    test("rejects, with expected error", () =>
+      expect(
+        helpers.run(Generator, generatorOptions).withLocalConfig({}),
+      ).rejects.toThrow("Missing generator configuration"));
+  });
+
   describe.each([
     {
       description: "generator configuration has invalid data format",


### PR DESCRIPTION
The user provides the universal generator configuration via the `@per1234/generator-kb-document` object in the `.yo-rc.json` file. This configuration contains data that is required for the generator to function.

The generator configuration might be missing for various reasons:

- User didn't provide a configuration
- User didn't name the configuration file correctly
- User didn't place the configuration file in the correct location
- User didn't use the correct top level key name in the file

Previously, a missing configuration did cause the generator run to fail at the JSON schema validation phase, as intended. However, the error message produced by the schema validator was difficult to interpret:

```text
$ npx yo @per1234/kb-document
✖ An error occured while running @per1234/kb-document:app#initializing
Error @per1234/kb-document

Generator configuration has an invalid data format:
[
  {
    "instancePath": "",
    "instancePath": "",
    "schemaPath": "#/required",
    "keyword": "required",
    "params": {
      "missingProperty": "documentPrimaryTemplatePath"
    },
    "message": "must have required property 'documentPrimaryTemplatePath'"
  }
]
```

In order to improve the user experience under these conditions, a dedicated check for missing generator configuration is added. This uses a bespoke error message that will clearly communicate the problem to the user if the validation fails.