### PR TITLE
Support providing answers via command line flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Project website: https://github.com/per1234/generator-kb-document
 - [Generator Usage](#generator-usage)
   - [Create New Document](#create-new-document)
   - [Add a Document Supplement File](#add-a-document-supplement-file)
+  - [Answer via Command Line Flag](#answer-via-command-line-flag)
 - [Example](#example)
 - [Knowledge Base Structure](#knowledge-base-structure)
   - [File Structure](#file-structure)
@@ -615,6 +616,24 @@ This procedure is used to add a supplement file to an existing knowledge base do
 1. At the end of the process you will see an "**A knowledge base document supplement file has been created at ...**" message printed in the terminal. Open the file at the path shown in the message.<br />
    You will see the file has been populated according to the [document file template](#document-file-template) and your answers to the prompts.
 1. Manually fill in the document content.
+
+### Answer via Command Line Flag
+
+As an alternative to providing answers via the human-friendly prompts interface, the generator supports providing answers via command line flags passed to the generator invocation:
+
+```text
+npx yo @per1234/kb-document --<prompt name>=<answer>
+```
+
+This can be useful for automated use cases for which the generator's interactive prompt interface is not appropriate.
+
+The built-in prompts have the following names:
+
+- **Which operation would you like to perform?**: `kbDocumentOperation`
+- **Knowledge base document title**: `kbDocumentTitle`
+- **Supplement title**: `kbDocumentSupplementTitle`
+
+As for additional [user-configured prompts](#prompts-configuration-file), the prompt name is defined by the `name` property of the [**Inquirer** `Question` object](#inquirer).
 
 <a name="generator-example"></a>
 

--- a/app/index.js
+++ b/app/index.js
@@ -336,52 +336,79 @@ export default class extends Generator {
       (promptConfiguration) => promptConfiguration.inquirer,
     );
 
-    // Present the universal prompts.
-    const promptsPromise = this.prompt(universalBuiltInInquirerPrompts).then(
-      (universalBuiltInAnswers) => {
-        this.#answers = universalBuiltInAnswers;
+    this.#answers = {};
 
-        // Validate the document title answer immediately so the user doesn't waste time answering all the additional prompts.
-        const documentFolderName = slug(this.#answers.kbDocumentTitle);
-        this.#documentFolderPath = this.destinationPath(
-          this.#generatorConfiguration.kbPath,
-          documentFolderName,
-        );
-        if (
-          this.#answers.kbDocumentOperation === "supplement" &&
-          !existsSync(this.#documentFolderPath)
-        ) {
-          return Promise.reject(
-            new Error(
-              `Target document "${this.#answers.kbDocumentTitle}" for the supplement file was not found.`,
-            ),
-          );
+    // Get answers from command line flags.
+    const setFlagAnswers = (inquirerPrompts) =>
+      inquirerPrompts.map((inquirerPrompt) => {
+        const updatedInquirerPrompt = inquirerPrompt;
+        if (inquirerPrompt.name in this.options) {
+          this.#answers[inquirerPrompt.name] =
+            this.options[inquirerPrompt.name];
+          // Don't present the prompt if answer provided via flag.
+          updatedInquirerPrompt.when = false;
+        } else {
+          updatedInquirerPrompt.when = true;
         }
 
-        const operationConditionalPrompts = supplementBuiltInPrompts.concat(
-          this.#promptsConfiguration,
-        );
-        const operationFilteredPrompts = operationConditionalPrompts.filter(
-          (prompt) =>
-            prompt.operations.includes(this.#answers.kbDocumentOperation),
-        );
-        this.#promptsConfiguration = universalBuiltInPrompts.concat(
-          operationFilteredPrompts,
-        );
+        return updatedInquirerPrompt;
+      });
 
-        const operationFilteredInquirerPrompts = operationFilteredPrompts.map(
-          (promptConfiguration) => promptConfiguration.inquirer,
-        );
-
-        // Present the additional prompts.
-        return this.prompt(operationFilteredInquirerPrompts).then(
-          (operationFilteredAnswers) => {
-            // Merge the answers to the additional prompts into the universal prompt answers.
-            Object.assign(this.#answers, operationFilteredAnswers);
-          },
-        );
-      },
+    const universalBuiltInInquirerPromptsPerFlagAnswers = setFlagAnswers(
+      universalBuiltInInquirerPrompts,
     );
+
+    // Present the universal prompts.
+    const promptsPromise = this.prompt(
+      universalBuiltInInquirerPromptsPerFlagAnswers,
+    ).then((universalBuiltInAnswers) => {
+      // Merge answers from the prompts into the answers from command line flags.
+      Object.assign(this.#answers, universalBuiltInAnswers);
+
+      // Validate the document title answer immediately so the user doesn't waste time answering all the additional prompts.
+      const documentFolderName = slug(this.#answers.kbDocumentTitle);
+      this.#documentFolderPath = this.destinationPath(
+        this.#generatorConfiguration.kbPath,
+        documentFolderName,
+      );
+      if (
+        this.#answers.kbDocumentOperation === "supplement" &&
+        !existsSync(this.#documentFolderPath)
+      ) {
+        return Promise.reject(
+          new Error(
+            `Target document "${this.#answers.kbDocumentTitle}" for the supplement file was not found.`,
+          ),
+        );
+      }
+
+      const operationConditionalPrompts = supplementBuiltInPrompts.concat(
+        this.#promptsConfiguration,
+      );
+      const operationFilteredPrompts = operationConditionalPrompts.filter(
+        (prompt) =>
+          prompt.operations.includes(this.#answers.kbDocumentOperation),
+      );
+      this.#promptsConfiguration = universalBuiltInPrompts.concat(
+        operationFilteredPrompts,
+      );
+
+      const operationFilteredInquirerPrompts = operationFilteredPrompts.map(
+        (promptConfiguration) => promptConfiguration.inquirer,
+      );
+
+      const operationFilteredInquirerPromptsPerFlagAnswers = setFlagAnswers(
+        operationFilteredInquirerPrompts,
+      );
+
+      // Present the additional prompts.
+      return this.prompt(operationFilteredInquirerPromptsPerFlagAnswers).then(
+        (operationFilteredAnswers) => {
+          // Merge the answers to the additional prompts into the universal prompt answers.
+          Object.assign(this.#answers, operationFilteredAnswers);
+        },
+      );
+    });
 
     return promptsPromise;
   }

--- a/app/index.js
+++ b/app/index.js
@@ -376,7 +376,7 @@ export default class extends Generator {
         // Present the additional prompts.
         return this.prompt(operationFilteredInquirerPrompts).then(
           (operationFilteredAnswers) => {
-            // Merge the answers to the additional prompts into the the universal prompt answers.
+            // Merge the answers to the additional prompts into the universal prompt answers.
             Object.assign(this.#answers, operationFilteredAnswers);
           },
         );

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -274,6 +274,18 @@ describe("invalid configuration", () => {
 describe("valid configuration", () => {
   describe.each([
     {
+      description: "answer from option",
+      testdataFolderName: "answer-from-option",
+      options: {
+        kbDocumentTitle: documentTitle,
+        fooPrompt: "fooValue",
+      },
+      answers: {
+        kbDocumentOperation: "new",
+      },
+      doInDirFunction: () => {},
+    },
+    {
       description: "no user prompts",
       testdataFolderName: "no-prompts-configuration",
       answers: {
@@ -569,6 +581,7 @@ describe("valid configuration", () => {
       testdataFolderName,
       answers,
       doInDirFunction,
+      options,
       sortFrontMatter,
       universalFrontMatter,
     }) => {
@@ -605,6 +618,7 @@ describe("valid configuration", () => {
           .run(Generator, generatorOptions)
           .withAnswers(answers)
           .withLocalConfig(localConfig)
+          .withOptions(options)
           .doInDir(doInDirFunction);
       });
 

--- a/tests/testdata/answer-from-option/document-primary.ejs
+++ b/tests/testdata/answer-from-option/document-primary.ejs
@@ -1,0 +1,3 @@
+# <%- kbDocumentTitle %>
+
+<%- fooPrompt %>

--- a/tests/testdata/answer-from-option/golden/foo-title/doc.md
+++ b/tests/testdata/answer-from-option/golden/foo-title/doc.md
@@ -1,0 +1,3 @@
+# Foo Title
+
+fooValue

--- a/tests/testdata/answer-from-option/prompts.js
+++ b/tests/testdata/answer-from-option/prompts.js
@@ -1,0 +1,12 @@
+const prompts = [
+  {
+    inquirer: {
+      type: "input",
+      name: "fooPrompt",
+      message: "Foo message:",
+    },
+    usages: ["content"],
+  },
+];
+
+export default prompts;


### PR DESCRIPTION
For automated use cases (e.g., users making integration tests for their generator configuration), the generator's interactive prompt interface is not appropriate.

Unfortunately Yeoman doesn't provide a built-in feature for setting answers via the generator invocation. This meant that, previously, it was impossible to do a run of the generator without using an interactive interface.

However, `yo` does accept arbitrary command line flags, the data from which is made available for use in the generator code. So I was able to implement the functionality (which really should be provided by the Yeoman codebase) in the generator codebase. This was done by setting the answer for any prompt for which an answer had already been provided via a flag in the `yo` invocation, and configuring that prompt to not be presented to the user. This means that if the user provides flags for all prompts, the generator will run without requiring interaction.