### PR TITLE
Use prompt-appropriate type for answers from flags

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -343,8 +343,19 @@ export default class extends Generator {
       inquirerPrompts.map((inquirerPrompt) => {
         const updatedInquirerPrompt = inquirerPrompt;
         if (inquirerPrompt.name in this.options) {
-          this.#answers[inquirerPrompt.name] =
-            this.options[inquirerPrompt.name];
+          let answerValue = this.options[inquirerPrompt.name];
+
+          // The flag system doesn't have any way to know the correct type for the option and the user doesn't have any
+          // control over the type it uses. So string values must be converted to arrays for prompt types that generate
+          // answer arrays.
+          if (
+            typeof answerValue === "string" &&
+            inquirerPrompt.type === "checkbox"
+          ) {
+            answerValue = [answerValue];
+          }
+
+          this.#answers[inquirerPrompt.name] = answerValue;
           // Don't present the prompt if answer provided via flag.
           updatedInquirerPrompt.when = false;
         } else {

--- a/tests/integration.js
+++ b/tests/integration.js
@@ -286,6 +286,18 @@ describe("valid configuration", () => {
       doInDirFunction: () => {},
     },
     {
+      description: "answer array from single option",
+      testdataFolderName: "answer-array-from-single-option",
+      options: {
+        kbDocumentTitle: documentTitle,
+        fooPrompt: "pippoChoice",
+      },
+      answers: {
+        kbDocumentOperation: "new",
+      },
+      doInDirFunction: () => {},
+    },
+    {
       description: "no user prompts",
       testdataFolderName: "no-prompts-configuration",
       answers: {

--- a/tests/testdata/answer-array-from-single-option/document-primary.ejs
+++ b/tests/testdata/answer-array-from-single-option/document-primary.ejs
@@ -1,0 +1,1 @@
+<%- kbDocumentFrontMatter %>

--- a/tests/testdata/answer-array-from-single-option/golden/foo-title/doc.md
+++ b/tests/testdata/answer-array-from-single-option/golden/foo-title/doc.md
@@ -1,0 +1,4 @@
+---
+tags:
+  - pippoChoice
+---

--- a/tests/testdata/answer-array-from-single-option/prompts.js
+++ b/tests/testdata/answer-array-from-single-option/prompts.js
@@ -1,0 +1,19 @@
+const prompts = [
+  {
+    frontMatterPath: "/tags",
+    inquirer: {
+      type: "checkbox",
+      name: "fooPrompt",
+      message: "Foo message:",
+      choices: [
+        {
+          name: "Pippo choice",
+          value: "pippoChoice",
+        },
+      ],
+    },
+    usages: ["front matter"],
+  },
+];
+
+export default prompts;


### PR DESCRIPTION
The "checkbox" prompt type allows the user to select multiple choices. For this reason, this prompt type produces an array of answers, rather than a single answer value as the other prompt types do.

Yeoman's command line flag parser produces an array of values when the same flag is passed multiple times in the `yo` invocation. This allows the user to produce answer data of an appropriate type for a "checkbox" prompt via flags when they wish to select multiple choices for the prompt. However, the flag system doesn't know anything about what the flag data will be used for so it will not produce answer data of array type if the user only selects a single choice. The flag system doesn't offer any way for the user to produce an array under these conditions.

So the type of answers from command line flags must be converted as appropriate for the prompt type by the generator.