### PR TITLE
Correct `git push` command in "bump package" script

### DIFF
--- a/assets/bump-package.sh
+++ b/assets/bump-package.sh
@@ -36,4 +36,5 @@ git \
   -m "Update package version to $1"
 
 git \
-  push
+  push \
+  --set-upstream origin bump-package


### PR DESCRIPTION
The `bump-package.sh` script handles all operations needed to bump the package version in preparation for a release. This includes pushing the automatically generated commit for the package.json update to the GitHub repository to prepare for the maintainer to submit the pull request.

Previously, on systems in which the `push.autoSetupRemote` Git configuration option had not been enabled, the `git push` command would fail:

```
fatal: The current branch bump-package has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin bump-package
```