### PR TITLE
Use official project name in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -29,9 +29,9 @@ body:
   - type: input
     id: project-version
     attributes:
-      label: generator-kb-document version
+      label: "@per1234/generator-kb-document version"
       description: |
-        Which version of generator-kb-document are you using?
+        Which version of @per1234/generator-kb-document are you using?
         _This should be the most recent version available._
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -17,16 +17,16 @@ body:
     attributes:
       label: Describe the current behavior
       description: |
-        What is the current behavior of generator-kb-document in relation to your request?
+        What is the current behavior of @per1234/generator-kb-document in relation to your request?
         How can we reproduce that behavior?
     validations:
       required: true
   - type: input
     id: project-version
     attributes:
-      label: generator-kb-document version
+      label: "@per1234/generator-kb-document version"
       description: |
-        Which version of generator-kb-document are you using?
+        Which version of @per1234/generator-kb-document are you using?
         _This should be the most recent version available._
     validations:
       required: true


### PR DESCRIPTION
The npm package name is used as the canonical project name. During the initial development, the package was named "generator-kb-document". The `@per1234` scope was later added to the package name. The project name references in the issue templates were not updated at that time.