### PR TITLE
Disable blank issue link in issue template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,7 @@
 # See:
 # https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
 
+blank_issues_enabled: false
 contact_links:
   - name: Learn about using this project
     url: https://github.com/per1234/generator-kb-document#readme


### PR DESCRIPTION
By default, GitHub's issue template chooser page includes an "Open a blank issue" link, which allows contributors to bypass the use of the issue templates.

This is not desirable because it allows contributors to submit issues that don't follow the standardized format that would otherwise be provided by submitting an issue via the form provided by the templates.

Some advanced contributors might prefer to compose their issues in an external text editor. The user who has a need for that and the competence to do it responsibly, will also be able to hack the URL in order to bypass the form based issue creation system:

https://github.com/per1234/generator-kb-document/issues/new