### PR TITLE
Specify license type in package metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@per1234/generator-kb-document",
       "version": "1.0.0",
+      "license": "MIT",
       "dependencies": {
         "ajv": "8.17.1",
         "ejs": "3.1.10",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "keywords": [
     "yeoman-generator"
   ],
+  "license": "MIT",
   "main": "app/index.js",
   "repository": "github:per1234/generator-kb-document",
   "type": "module"


### PR DESCRIPTION
I had hoped that, in the absence of a `license` metadata field, npm would be smart enough to get the license type from the canonical source that is the license file. That would have allowed me to avoid the duplication of this information. Unfortunately, but I see that the npm package registry page for the package shows "license: none", and the `npm view "@per1234/generator-kb-document"` output as "Proprietary".