### PR TITLE
Update package version to prerelease

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@per1234/generator-kb-document",
-  "version": "1.0.0",
+  "version": "1.0.1-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@per1234/generator-kb-document",
-      "version": "1.0.0",
+      "version": "1.0.1-beta.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "8.17.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@per1234/generator-kb-document",
   "description": "Yeoman generator for creating documents in a Markdown file-based knowledge base.",
-  "version": "1.0.0",
+  "version": "1.0.1-beta.0",
   "dependencies": {
     "ajv": "8.17.1",
     "ejs": "3.1.10",


### PR DESCRIPTION
A prerelease version is set in the package's metadata between releases in order to allow the maintainer to determine that a user is using the beta version of the package instead of the release.