### PR TITLE
Configure version bump script to use appropriate prerelease version format

### DIFF
--- a/assets/bump-package.sh
+++ b/assets/bump-package.sh
@@ -24,6 +24,7 @@ git \
 npm \
   version \
   --no-git-tag-version \
+  --preid "beta" \
   "$1"
 
 git \


### PR DESCRIPTION
A prerelease version is set in the package's metadata between releases in order to allow the maintainer to determine that a user is using the beta version of the package instead of the release.

A script is provided to facilitate the process of bumping the package version. Previously, this used the default behavior of `npm version`, which produces pre-release versions with an X.Y.Z-n format (e.g., 1.2.3-0).

Prereleases may be made for a variety of reasons. They are often made as "release candidates", where the release serves as a marker for a point in the revision history that is considered to be suitable for evaluation for a possible production release. The prereleases that are produced using this script are not for that purpose. So a version number that only indicates that it is a prerelease is not sufficient to communicate the nature of the version. This is why it is a common convention to use a standard prefix on the prerelease version number suffix to indicate the nature of the version. The prefix "rc" is used to communicate that it is a release candidate. For our purposes, "beta" will be an appropriate prefix.